### PR TITLE
Remove return statement for binary search

### DIFF
--- a/crypto/src/main/scala/fluence/crypto/CryptoSearching.scala
+++ b/crypto/src/main/scala/fluence/crypto/CryptoSearching.scala
@@ -56,13 +56,14 @@ object CryptoSearching {
     @tailrec
     private def binarySearchRec[B](elem: B, from: Int, to: Int, ordering: Ordering[B], decrypt: A ⇒ B): SearchResult = {
 
-      if (from == to) return InsertionPoint(from)
-
-      val idx = from + (to - from - 1) / 2
-      math.signum(ordering.compare(elem, decrypt(coll(idx)))) match {
-        case -1 ⇒ binarySearchRec(elem, from, idx, ordering, decrypt)
-        case 1  ⇒ binarySearchRec(elem, idx + 1, to, ordering, decrypt)
-        case _  ⇒ Found(idx)
+      if (from == to) InsertionPoint(from)
+      else {
+        val idx = from + (to - from - 1) / 2
+        math.signum(ordering.compare(elem, decrypt(coll(idx)))) match {
+          case -1 ⇒ binarySearchRec(elem, from, idx, ordering, decrypt)
+          case 1  ⇒ binarySearchRec(elem, idx + 1, to, ordering, decrypt)
+          case _  ⇒ Found(idx)
+        }
       }
     }
   }


### PR DESCRIPTION
It's better not to use return keyword in scala as it's not referentially transparent and side-effective operation.

by the link below there's more information about returns
https://tpolecat.github.io/2014/05/09/return.html