### PR TITLE
Adding fork of Asmble

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val vm = (project in file("vm"))
   .settings(
     commons,
     libraryDependencies ++= Seq(
-      "com.github.cretz.asmble" % "asmble-compiler" % "0.3.0",
+      "com.github.cretz.asmble" % "asmble-compiler" % "0.4.0-fl",
       cats,
       catsEffect,
       pureConfig,

--- a/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
+++ b/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
@@ -136,7 +136,7 @@ class WasmVmSpec extends WordSpec with Matchers {
 
       val res = for {
         vm <- WasmVm[IO](Seq(mulFile, sumFile))
-        mulResult ← vm.invoke[IO](Some("$multiplier"), "mul", Seq("100", "13"))
+        mulResult ← vm.invoke[IO](Some("multiplier"), "mul", Seq("100", "13"))
         sumResult ← vm.invoke[IO](None, "sum", Seq("100", "13"))
       } yield {
         mulResult shouldBe Some(1300)


### PR DESCRIPTION
Change Asmble dependency to [Fluence's fork](https://github.com/fluencelabs/asmble), as we need to tune it up.