### PR TITLE
Remake Vm errors hierarchy 

### DIFF
--- a/statemachine/src/main/scala/fluence/statemachine/tx/VmOperationInvoker.scala
+++ b/statemachine/src/main/scala/fluence/statemachine/tx/VmOperationInvoker.scala
@@ -82,8 +82,9 @@ object VmOperationInvoker {
    *
    * @param vmError error returned from VM
    */
+  // todo handle different error types separately
   private def convertToStateMachineError(vmError: VmError): StateMachineError =
-    VmRuntimeError(vmError.errorKind.getClass.getSimpleName, vmError.message, vmError)
+    VmRuntimeError(vmError.getClass.getSimpleName, vmError.getMessage, vmError)
 
   /**
    * Produces [[StateMachineError]] corresponding to payload that cannot be parsed to a function call.

--- a/vm/src/main/scala/fluence/vm/ModuleInstance.scala
+++ b/vm/src/main/scala/fluence/vm/ModuleInstance.scala
@@ -23,7 +23,7 @@ import cats.Monad
 import cats.data.EitherT
 import fluence.crypto.CryptoError
 import fluence.vm.ModuleInstance.nameAsStr
-import fluence.vm.VmError.MethodsErrors.ApplyError
+import fluence.vm.VmError.WasmVmError.ApplyError
 import fluence.vm.VmError.{InitializationError, InternalVmError}
 
 import scala.language.higherKinds

--- a/vm/src/main/scala/fluence/vm/VmError.scala
+++ b/vm/src/main/scala/fluence/vm/VmError.scala
@@ -16,7 +16,7 @@
 
 package fluence.vm
 
-import fluence.vm.VmError.MethodsErrors.{ApplyError, GetVmStateError, InvokeError}
+import fluence.vm.VmError.WasmVmError.{ApplyError, GetVmStateError, InvokeError}
 
 import scala.util.control.NoStackTrace
 
@@ -85,13 +85,42 @@ object VmError {
     override val cause: Some[Throwable]
   ) extends VmErrorProxy(message, cause) with WasmError with ApplyError with InvokeError
 
-  // todo docs
-  object MethodsErrors {
+  /**
+   * Contains errors for each [[fluence.vm.WasmVm]] public methods for reaching type-safe
+   * working with produced errors. For example:
+   * {{{
+   *
+   *  val vm: fluence.vm.WasmVm = ???
+   *     vm.invoke[IO](None, "fnName", Seq()).leftMap {
+   *       case InvalidArgError(message, cause) ⇒  ???
+   *       case NoSuchFnError(message, cause) ⇒  ???
+   *       case TrapError(message, cause) ⇒ ???
+   *       // case InternalVmError(message, cause) ⇒ ???
+   *     }
+   *
+   * }}}
+   *
+   *   Compiler checks that all of possible error types will be handled.
+   *   If some of error types will not be handled compiler produce warning like this:
+   *
+   *   {{{
+   *     Warning:(103, 50) match may not be exhaustive.
+   *     It would fail on the following input: InternalVmError(_, _)
+   *     vm.invoke[IO](None, "fnName", Seq()).leftMap {
+   *   }}}
+   *
+   *   This mean that [[InternalVmError]] will not be handled.
+   *
+   */
+  object WasmVmError {
 
+    /** Error for [[fluence.vm.WasmVm:apply()]] method */
     sealed trait ApplyError extends VmError
 
+    /** Error for [[fluence.vm.WasmVm:invoke()]] method */
     sealed trait InvokeError extends VmError
 
+    /** Error for [[fluence.vm.WasmVm:getVmState()]] method */
     sealed trait GetVmStateError extends VmError
 
   }

--- a/vm/src/main/scala/fluence/vm/VmError.scala
+++ b/vm/src/main/scala/fluence/vm/VmError.scala
@@ -16,66 +16,84 @@
 
 package fluence.vm
 
-import fluence.vm.VmError.VmErrorKind
+import fluence.vm.VmError.MethodsErrors.{ApplyError, GetVmStateError, InvokeError}
 
 import scala.util.control.NoStackTrace
 
 /**
  * This type describes all errors appears in VM.
  */
-case class VmError(
-  message: String,
-  causedBy: Option[Throwable],
-  errorKind: VmErrorKind
-) extends Throwable
+sealed trait VmError extends NoStackTrace
+
+abstract class VmErrorProxy(
+  protected val message: String,
+  protected val cause: Option[Throwable]
+) extends Throwable(message, cause.orNull, true, false) with VmError
 
 object VmError {
-
-  /** Root type for VM error kinds. */
-  sealed trait VmErrorKind
 
   /**
    * This type of error indicates some unexpected internal error has occurred in
    * the Virtual Machine.
    */
-  object InternalVmError extends VmErrorKind
+  case class InternalVmError(
+    override val message: String,
+    override val cause: Option[Throwable] = None
+  ) extends VmErrorProxy(message, cause) with ApplyError with InvokeError with GetVmStateError
 
   /** Errors related to external WASM code. */
-  sealed trait WasmError extends VmErrorKind
+  sealed trait WasmError extends VmError
 
   /**
    * Indicates error when VM starts. It might be a problem with translation WASM
    * code to 'bytecode' or module instantiation. Module initialization is creation of
    * instance class that corresponds to WASM module.
    */
-  object InitializationError extends WasmError
+  case class InitializationError(
+    override val message: String,
+    override val cause: Option[Throwable] = None
+  ) extends VmErrorProxy(message, cause) with WasmError with ApplyError
 
   /**
    * Indicates that some of the client input values are invalid. For example number
    * of types of argument is not correct or specified fn isn't exists.
    */
-  sealed trait InvocationError extends WasmError
+  sealed trait InvocationError extends WasmError with InvokeError
 
   /**
    * Indicates that arguments for fn invocation is not valid.
    */
-  object InvalidArgError extends InvocationError
+  case class InvalidArgError(
+    override val message: String,
+    override val cause: Option[Throwable] = None
+  ) extends VmErrorProxy(message, cause) with InvocationError
 
   /**
    * Indicates that fn with specified name wasn't found in a instance of VM.
    */
-  object NoSuchFnError extends InvocationError
+  case class NoSuchFnError(
+    override val message: String,
+    override val cause: Option[Throwable] = None
+  ) extends VmErrorProxy(message, cause) with InvocationError with ApplyError
 
   /**
    * Indicates that WASM code execution was failed, some WASM instruction was
    * felled into the trap.
    */
-  object TrapError extends WasmError
+  case class TrapError(
+    override val message: String,
+    override val cause: Some[Throwable]
+  ) extends VmErrorProxy(message, cause) with WasmError with ApplyError with InvokeError
 
-  def apply(exception: Throwable, kind: VmErrorKind): VmError =
-    VmError(exception.getMessage, Some(exception), kind)
+  // todo docs
+  object MethodsErrors {
 
-  def apply(message: String, kind: VmErrorKind): VmError =
-    VmError(message, None, kind)
+    sealed trait ApplyError extends VmError
+
+    sealed trait InvokeError extends VmError
+
+    sealed trait GetVmStateError extends VmError
+
+  }
 
 }

--- a/vm/src/main/scala/fluence/vm/WasmVm.scala
+++ b/vm/src/main/scala/fluence/vm/WasmVm.scala
@@ -28,7 +28,7 @@ import cats.{Applicative, Id, Monad}
 import fluence.crypto.Crypto
 import fluence.crypto.hash.JdkCryptoHasher
 import fluence.vm.VmError.{InitializationError, InternalVmError}
-import fluence.vm.VmError.MethodsErrors.{ApplyError, GetVmStateError, InvokeError}
+import fluence.vm.VmError.WasmVmError.{ApplyError, GetVmStateError, InvokeError}
 import fluence.vm.WasmVmImpl._
 import fluence.vm.config.VmConfig
 import fluence.vm.config.VmConfig._

--- a/vm/src/main/scala/fluence/vm/WasmVmImpl.scala
+++ b/vm/src/main/scala/fluence/vm/WasmVmImpl.scala
@@ -22,7 +22,7 @@ import cats.data.EitherT
 import cats.effect.{IO, LiftIO}
 import cats.{Functor, Monad}
 import fluence.crypto.Crypto.Hasher
-import fluence.vm.VmError.MethodsErrors.{GetVmStateError, InvokeError}
+import fluence.vm.VmError.WasmVmError.{GetVmStateError, InvokeError}
 import fluence.vm.VmError.{InvalidArgError, _}
 import fluence.vm.WasmVmImpl._
 import scodec.bits.ByteVector

--- a/vm/src/main/scala/fluence/vm/WasmVmImpl.scala
+++ b/vm/src/main/scala/fluence/vm/WasmVmImpl.scala
@@ -22,7 +22,8 @@ import cats.data.EitherT
 import cats.effect.{IO, LiftIO}
 import cats.{Functor, Monad}
 import fluence.crypto.Crypto.Hasher
-import fluence.vm.VmError.{InternalVmError, InvalidArgError, NoSuchFnError, TrapError}
+import fluence.vm.VmError.MethodsErrors.{GetVmStateError, InvokeError}
+import fluence.vm.VmError.{InvalidArgError, _}
 import fluence.vm.WasmVmImpl._
 import scodec.bits.ByteVector
 
@@ -49,8 +50,7 @@ class WasmVmImpl(
     moduleName: Option[String],
     fnName: String,
     fnArgs: Seq[String]
-  ): EitherT[F, VmError, Option[Any]] = {
-
+  ): EitherT[F, InvokeError, Option[Any]] = {
     val fnId = FunctionId(moduleName, AsmExtKt.getJavaIdent(fnName))
 
     for {
@@ -58,7 +58,7 @@ class WasmVmImpl(
       wasmFn <- EitherT
         .fromOption(
           functionsIndex.get(fnId),
-          VmError(s"Unable to find a function with the name=$fnId", NoSuchFnError)
+          NoSuchFnError(s"Unable to find a function with the name=$fnId")
         )
 
       arguments ← parseArguments(fnArgs, wasmFn)
@@ -77,19 +77,20 @@ class WasmVmImpl(
    * }}}
    * '''Note!''' It's very expensive operation try to avoid frequent use.
    */
-  override def getVmState[F[_]: LiftIO: Monad]: EitherT[F, VmError, ByteVector] =
+  override def getVmState[F[_]: LiftIO: Monad]: EitherT[F, GetVmStateError, ByteVector] =
     modulesIndex
-      .foldLeft(EitherT.rightT[F, VmError](Array[Byte]())) {
+      .foldLeft(EitherT.rightT[F, GetVmStateError](Array[Byte]())) {
         case (acc, instance) ⇒
           for {
-            moduleStateHash <- instance.innerState(arr ⇒ hasher[F](arr))
+            moduleStateHash ← instance
+              .innerState(arr ⇒ hasher[F](arr))
 
             prevModulesHash ← acc
 
             concatHashes ← safeConcat(moduleStateHash, prevModulesHash)
 
             resultHash ← hasher(concatHashes)
-              .leftMap(e ⇒ VmError(s"Getting VM state for module=$instance failed", Some(e), InternalVmError))
+              .leftMap(e ⇒ InternalVmError(s"Getting VM state for module=$instance failed", Some(e)): GetVmStateError)
 
           } yield resultHash
       }
@@ -130,9 +131,9 @@ object WasmVmImpl {
      * @param args arguments for calling this fn.
      * @tparam F a monad with an ability to absorb 'IO'
      */
-    def apply[F[_]: Functor: LiftIO](args: List[AnyRef]): EitherT[F, VmError, AnyRef] =
+    def apply[F[_]: Functor: LiftIO](args: List[AnyRef]): EitherT[F, InvokeError, AnyRef] =
       EitherT(IO(javaMethod.invoke(module.instance, args: _*)).attempt.to[F])
-        .leftMap(e ⇒ VmError(s"Function $this with args: $args was failed", Some(e), TrapError))
+        .leftMap(e ⇒ TrapError(s"Function $this with args: $args was failed", Some(e)))
 
     override def toString: String = functionId.toString
   }
@@ -142,26 +143,26 @@ object WasmVmImpl {
     arg: String,
     castFn: String ⇒ Any,
     errorMsg: String
-  ): Either[VmError, AnyRef] =
+  ): Either[InvalidArgError, AnyRef] =
     // it's important to cast to AnyRef type, because args should be used in
     // Method.invoke(...) as Object type
     Try(castFn(arg).asInstanceOf[AnyRef]).toEither.left
-      .map(e ⇒ VmError(errorMsg, Some(e), InvalidArgError))
+      .map(e ⇒ InvalidArgError(errorMsg, Some(e)))
 
   /** Safe array concatenation. Prevents  array overflow or OOM. */
   private def safeConcat[F[_]: LiftIO: Monad](
     first: Array[Byte],
     second: Array[Byte]
-  ): EitherT[F, VmError, Array[Byte]] = {
+  ): EitherT[F, InternalVmError, Array[Byte]] = {
     EitherT.fromEither {
       Try(Array.concat(second, first)).toEither
-    }.leftMap(e ⇒ VmError("Arrays concatenation failed", Some(e), InternalVmError))
+    }.leftMap(e ⇒ InternalVmError("Arrays concatenation failed", Some(e)))
   }
 
   private def parseArguments[F[_]: LiftIO: Monad](
     fnArgs: Seq[String],
     wasmFn: WasmFunction
-  ): EitherT[F, VmError, List[AnyRef]] = {
+  ): EitherT[F, InvalidArgError, List[AnyRef]] = {
 
     // Maps args to params
     val required = wasmFn.javaMethod.getParameterTypes.length
@@ -170,9 +171,8 @@ object WasmVmImpl {
       _ ← EitherT.cond(
         required == fnArgs.size,
         (),
-        VmError(
-          s"Invalid number of arguments, expected=$required, actually=${fnArgs.size} for fn=$wasmFn",
-          InvalidArgError
+        InvalidArgError(
+          s"Invalid number of arguments, expected=$required, actually=${fnArgs.size} for fn=$wasmFn"
         )
       )
 
@@ -185,15 +185,14 @@ object WasmVmImpl {
             case cl if cl == classOf[Double] ⇒ cast(arg, _.toDouble, s"Arg $index of '$arg' not a double")
             case _ ⇒
               Left(
-                VmError(
-                  s"Invalid type for param $index: $paramType, expected [i32|i64|f32|f64]",
-                  InvalidArgError
+                InvalidArgError(
+                  s"Invalid type for param $index: $paramType, expected [i32|i64|f32|f64]"
                 )
               )
           }
       }
 
-      result ← list2Either[F, VmError, AnyRef](args.toList)
+      result ← list2Either[F, InvalidArgError, AnyRef](args.toList)
 
     } yield result
 

--- a/vm/src/main/scala/fluence/vm/package.scala
+++ b/vm/src/main/scala/fluence/vm/package.scala
@@ -15,8 +15,9 @@
  */
 
 package fluence
-import cats.Applicative
+import cats.{Applicative, Functor}
 import cats.data.EitherT
+import cats.effect.IO
 
 import scala.language.higherKinds
 
@@ -32,6 +33,15 @@ package object vm {
     // unfortunately Idea don't understand this and show error in Editor
     val either: Either[A, List[B]] = list.sequence
     EitherT.fromEither[F](either)
+  }
+
+  implicit class VmErrorMapper[F[_]: Functor, E <: VmError, T](eitherT: EitherT[F, E, T]) {
+
+    def toVmError: EitherT[F, VmError, T] = {
+      eitherT.leftMap { e: VmError ⇒
+        e
+      }
+    }
   }
 
 }

--- a/vm/src/test/scala/fluence/vm/ModuleInstanceSpec.scala
+++ b/vm/src/test/scala/fluence/vm/ModuleInstanceSpec.scala
@@ -41,9 +41,9 @@ class ModuleInstanceSpec extends WordSpec with Matchers with MockitoSugar {
           case Right(_) ⇒
             fail("Should be error appeared")
           case Left(e) ⇒
-            e.message shouldBe "Unable to initialize module=test-module-name"
-            e.causedBy.get shouldBe a[RuntimeException]
-            e.errorKind shouldBe InitializationError
+            e.getMessage shouldBe "Unable to initialize module=test-module-name"
+            e.getCause shouldBe a[RuntimeException]
+            e shouldBe a[InitializationError]
         }
       }
 
@@ -58,9 +58,9 @@ class ModuleInstanceSpec extends WordSpec with Matchers with MockitoSugar {
           case Right(_) ⇒
             fail("Should be error appeared")
           case Left(e) ⇒
-            e.message shouldBe "Unable to getting memory from module=test-module-name"
-            e.causedBy.get shouldBe a[InvocationTargetException]
-            e.errorKind shouldBe InternalVmError
+            e.getMessage shouldBe "Unable to getting memory from module=test-module-name"
+            e.getCause shouldBe a[InvocationTargetException]
+            e shouldBe a[InternalVmError]
         }
       }
     }
@@ -106,8 +106,8 @@ class ModuleInstanceSpec extends WordSpec with Matchers with MockitoSugar {
           createInstance(instance).innerState(arr ⇒ EitherT.leftT(CryptoError("error!"))).value.left.get
 
         result.message shouldBe "Getting internal state for module=test-module-name failed"
-        result.causedBy.get shouldBe a[CryptoError]
-        result.errorKind shouldBe InternalVmError
+        result.getCause shouldBe a[CryptoError]
+        result shouldBe a[InternalVmError]
       }
 
       "working with memory is failed" in {
@@ -117,7 +117,7 @@ class ModuleInstanceSpec extends WordSpec with Matchers with MockitoSugar {
         val result = createInstance(instance).innerState(arr ⇒ EitherT.rightT(arr)).value.left.get
 
         result.message shouldBe "Presenting memory as an array for module=test-module-name failed"
-        result.errorKind shouldBe InternalVmError
+        result shouldBe a[InternalVmError]
       }
     }
 

--- a/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
+++ b/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
@@ -38,8 +38,8 @@ class WasmVmSpec extends WordSpec with Matchers {
         } yield vm
 
         val error = res.failed()
-        error.errorKind shouldBe InternalVmError
-        error.message should startWith("Unable to read a config for the namespace")
+        error shouldBe a[InternalVmError]
+        error.getMessage should startWith("Unable to read a config for the namespace")
       }
 
       "file not found" in {
@@ -48,8 +48,8 @@ class WasmVmSpec extends WordSpec with Matchers {
         } yield vm
 
         val error = res.failed()
-        error.errorKind shouldBe InitializationError
-        error.message should startWith("Preparing execution context before execution was failed for")
+        error shouldBe a[InitializationError]
+        error.getMessage should startWith("Preparing execution context before execution was failed for")
       }
 
       "2 module has function with equal name" in {
@@ -61,8 +61,8 @@ class WasmVmSpec extends WordSpec with Matchers {
         } yield vm
 
         val error = res.failed()
-        error.errorKind shouldBe InitializationError
-        error.message should startWith("The function '<no-name>.sum' was already registered")
+        error shouldBe a[InitializationError]
+        error.getMessage should startWith("The function '<no-name>.sum' was already registered")
       }
 
       // todo add more error cases with prepareContext and module initialization


### PR DESCRIPTION

Allows type-safe working with produced errors. For example:
  ```
  val vm: fluence.vm.WasmVm = ???
     vm.invoke[IO](None, "fnName", Seq()).leftMap {
       case InvalidArgError(message, cause) ⇒  ???
       case NoSuchFnError(message, cause) ⇒  ???
       case TrapError(message, cause) ⇒ ???
       // case InternalVmError(message, cause) ⇒ ???
     }
```
   
Compiler checks that all of possible error types will be handled. If some of error types will not be handled compiler produce warning like this:
```  
     Warning:(103, 50) match may not be exhaustive.
     It would fail on the following input: InternalVmError(_, _)
     vm.invoke[IO](None, "fnName", Seq()).leftMap {
```
   This mean that {@link InternalVmError} will not be handled.