### PR TITLE
Vm examples refactoring

### DIFF
--- a/vm/examples/counter/Cargo.toml
+++ b/vm/examples/counter/Cargo.toml
@@ -3,9 +3,9 @@ name = "counter"
 version = "0.1.0"
 authors = ["C.Solovev <constantine@fluence.one>"]
 
-[[bin]]
+[lib]
 name = "counter"
-path = "src/main/rust/main.rs"
+path = "src/main/rust/lib.rs"
 target = "wasm32-unknown-unknown"
 
 [dependencies]

--- a/vm/examples/counter/Cargo.toml
+++ b/vm/examples/counter/Cargo.toml
@@ -7,5 +7,6 @@ authors = ["C.Solovev <constantine@fluence.one>"]
 name = "counter"
 path = "src/main/rust/lib.rs"
 target = "wasm32-unknown-unknown"
+crate-type = ["cdylib"]
 
 [dependencies]

--- a/vm/examples/counter/src/main/rust/lib.rs
+++ b/vm/examples/counter/src/main/rust/lib.rs
@@ -13,7 +13,3 @@ pub unsafe fn inc() {
 pub unsafe fn get() -> i64 {
     COUNTER_.get()
 }
-
-fn main() {
-    // do nothing
-}

--- a/vm/examples/sqldb/Cargo.toml
+++ b/vm/examples/sqldb/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["C.Solovev <constantine@fluence.one>"]
 name = "sqldb"
 path = "src/main/rust/lib.rs"
 target = "wasm32-unknown-unknown"
+crate-type = ["cdylib"]
 
 [dependencies]
 

--- a/vm/examples/sqldb/Cargo.toml
+++ b/vm/examples/sqldb/Cargo.toml
@@ -3,9 +3,9 @@ name = "sqldb"
 version = "0.1.0"
 authors = ["C.Solovev <constantine@fluence.one>"]
 
-[[bin]]
+[lib]
 name = "sqldb"
-path = "src/main/rust/main.rs"
+path = "src/main/rust/lib.rs"
 target = "wasm32-unknown-unknown"
 
 [dependencies]

--- a/vm/examples/sqldb/src/main/rust/lib.rs
+++ b/vm/examples/sqldb/src/main/rust/lib.rs
@@ -66,7 +66,3 @@ pub fn next_field() -> f64 {
 fn run_query<T, F : FnOnce(MutexGuard<Db<i32>>) -> T>(query: F) -> T {
     query(sql_db::DB.lock().expect("Can't take a Database."))
 }
-
-fn main() {
-    // do nothing
-}


### PR DESCRIPTION
VM Rust examples are built as libraries now. 