### PR TITLE
Fix rust integration issues

### DIFF
--- a/vm/src/main/scala/fluence/vm/AsmleWasmVm.scala
+++ b/vm/src/main/scala/fluence/vm/AsmleWasmVm.scala
@@ -16,6 +16,7 @@
 
 package fluence.vm
 import java.lang.reflect.Method
+import java.nio.ByteOrder
 import java.nio.charset.Charset
 
 import asmble.compile.jvm.AsmExtKt
@@ -275,13 +276,15 @@ class AsmleWasmVm(
       readResult <- EitherT
         .fromEither[F](
           Try {
+            val wasmMemoryView = wasmMemory.duplicate()
+            wasmMemoryView.order(ByteOrder.LITTLE_ENDIAN)
+
             // each result has the next structure in Wasm memory: | size (4 bytes) | result buffer (size bytes) |
-            val resultSize = wasmMemory.getInt(offset)
+            val resultSize = wasmMemoryView.getInt(offset)
             // size of Int in bytes
             val intBytesSize = 4
 
             val resultBuffer = new Array[Byte](resultSize)
-            val wasmMemoryView = wasmMemory.duplicate()
             wasmMemoryView.position(offset + intBytesSize)
             wasmMemoryView.get(resultBuffer)
             resultBuffer

--- a/vm/src/main/scala/fluence/vm/ModuleInstance.scala
+++ b/vm/src/main/scala/fluence/vm/ModuleInstance.scala
@@ -15,7 +15,7 @@
  */
 
 package fluence.vm
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 
 import asmble.run.jvm.Module.Compiled
 import asmble.run.jvm.ScriptContext

--- a/vm/src/test/resources/wast/bad-allocation-function.wast
+++ b/vm/src/test/resources/wast/bad-allocation-function.wast
@@ -11,8 +11,9 @@
         (i64.const 9223372036854775807)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/counter-copy.wast
+++ b/vm/src/test/resources/wast/counter-copy.wast
@@ -11,8 +11,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/counter.wast
+++ b/vm/src/test/resources/wast/counter.wast
@@ -10,8 +10,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/mul.wast
+++ b/vm/src/test/resources/wast/mul.wast
@@ -11,8 +11,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/no-getMemory.wast
+++ b/vm/src/test/resources/wast/no-getMemory.wast
@@ -7,8 +7,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/simple-array-mutation.wast
+++ b/vm/src/test/resources/wast/simple-array-mutation.wast
@@ -10,8 +10,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/simple-array-returning.wast
+++ b/vm/src/test/resources/wast/simple-array-returning.wast
@@ -12,8 +12,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/simple-string-passing.wast
+++ b/vm/src/test/resources/wast/simple-string-passing.wast
@@ -10,8 +10,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/sum-copy.wast
+++ b/vm/src/test/resources/wast/sum-copy.wast
@@ -11,8 +11,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/sum-with-trap.wast
+++ b/vm/src/test/resources/wast/sum-with-trap.wast
@@ -10,8 +10,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/resources/wast/sum.wast
+++ b/vm/src/test/resources/wast/sum.wast
@@ -11,8 +11,9 @@
         (i32.const 10000)
     )
 
-    (func (export "deallocate") (param $0 i32) (return)
+    (func (export "deallocate") (param $address i32) (param $size i32) (return)
         ;; in this simple example deallocation function does nothing
+        (drop)
         (drop)
     )
 

--- a/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
+++ b/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
@@ -53,8 +53,10 @@ class WasmVmSpec extends WordSpec with Matchers {
       }
 
       "2 module has function with equal name" ignore {
-        val sum1File = getClass.getResource("/wast/no-getMemory.wast").getPath // module without name with function "test"
-        val sum2File = getClass.getResource("/wast/bad-allocation-function.wast").getPath // module without name with function "test"
+        // module without name and with some functions with the same name ("allocate", "deallocate", "test", ...)
+        val sum1File = getClass.getResource("/wast/no-getMemory.wast").getPath
+        // module without name and with some functions with the same name ("allocate", "deallocate", "test", ...)
+        val sum2File = getClass.getResource("/wast/bad-allocation-function.wast").getPath
 
         val res = for {
           vm <- WasmVm[IO](Seq(sum1File, sum2File))
@@ -62,7 +64,7 @@ class WasmVmSpec extends WordSpec with Matchers {
 
         val error = res.failed()
         error shouldBe a[InitializationError]
-        error.getMessage should startWith("The function '<no-name>.test' was already registered")
+        error.getMessage should endWith("was already registered")
       }
 
       // todo add more error cases with prepareContext and module initialization

--- a/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
+++ b/vm/src/test/scala/fluence/vm/WasmVmSpec.scala
@@ -52,7 +52,7 @@ class WasmVmSpec extends WordSpec with Matchers {
         error.getMessage should startWith("Preparing execution context before execution was failed for")
       }
 
-      "2 module has function with equal name" ignore {
+      "2 module has function with equal name" in {
         // module without name and with some functions with the same name ("allocate", "deallocate", "test", ...)
         val sum1File = getClass.getResource("/wast/no-getMemory.wast").getPath
         // module without name and with some functions with the same name ("allocate", "deallocate", "test", ...)


### PR DESCRIPTION
Fix rust integration issues:
  - added additional supplied parameter to deallocate method that represent size of freeing memory;
  - added order(ByteOrder.LITTLE_ENDIAN) before int has beed read;
  - fixed test when 2 module has function with equal name.