### PR TITLE
Force bouncycastle to 1.60

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,21 +24,12 @@ rustup: &rustup
       ~/.cargo/bin/rustup toolchain install nightly-2019-03-10 # in case some other toolchain was already installed
       ~/.cargo/bin/rustup target add wasm32-unknown-unknown --toolchain nightly-2019-03-10
 
-jce_policy: &jce_policy
-  - run: |
-      curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/jce_policy.zip
-      unzip -o /tmp/jce_policy.zip -d /tmp
-      sudo mv -f /tmp/UnlimitedJCEPolicyJDK8/US_export_policy.jar $JAVA_HOME/jre/lib/security/US_export_policy.jar
-      sudo mv -f /tmp/UnlimitedJCEPolicyJDK8/local_policy.jar $JAVA_HOME/jre/lib/security/local_policy.jar
-      rm -rf /tmp/UnlimitedJCEPolicyJDK8 /tmp/jce_policy.zip
-
 version: 2
 jobs:
   sbt all tests:
     <<: *jdk_image
     steps:
       - checkout
-      - <<: *jce_policy
       - <<: *rc
       - <<: *rustup
       - run: PATH="$PATH:$HOME/.cargo/bin:" SBT_OPTS="-Xms2048M -Xmx2048M -Xss6M" sbt -mem 2048 test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
-jdk: &jdk
-  image: circleci/openjdk:8-jdk-node
-
 just_jdk: &jdk_image
   docker:
-    - *jdk
+    - image: circleci/openjdk:8-jdk-node
 
 rc: &rc
   restore_cache:
@@ -27,12 +24,21 @@ rustup: &rustup
       ~/.cargo/bin/rustup toolchain install nightly-2019-03-10 # in case some other toolchain was already installed
       ~/.cargo/bin/rustup target add wasm32-unknown-unknown --toolchain nightly-2019-03-10
 
+jce_policy: &jce_policy
+  - run: |
+      curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/jce_policy.zip
+      unzip -o /tmp/jce_policy.zip -d /tmp
+      sudo mv -f /tmp/UnlimitedJCEPolicyJDK8/US_export_policy.jar $JAVA_HOME/jre/lib/security/US_export_policy.jar
+      sudo mv -f /tmp/UnlimitedJCEPolicyJDK8/local_policy.jar $JAVA_HOME/jre/lib/security/local_policy.jar
+      rm -rf /tmp/UnlimitedJCEPolicyJDK8 /tmp/jce_policy.zip
+
 version: 2
 jobs:
   sbt all tests:
     <<: *jdk_image
     steps:
       - checkout
+      - <<: *jce_policy
       - <<: *rc
       - <<: *rustup
       - run: PATH="$PATH:$HOME/.cargo/bin:" SBT_OPTS="-Xms2048M -Xmx2048M -Xss6M" sbt -mem 2048 test
@@ -165,29 +171,14 @@ jobs:
             - fluence-js/node_modules
           key: fluence-js-{{ checksum "fluence-js/package-lock.json" }}
 
-  fluence book: #TODO: doesn't work, fix
-    docker:
-      - image: circleci/rust:latest
-    steps:
-      - checkout
-      - run: |
-          eval `ssh-agent` && ssh-add ~/.ssh/id_rsa # https://github.com/rust-lang/cargo/issues/2429
-          test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update
-          test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.1" mdbook
-          cargo install-update -a
-          cd docs/
-          mdbook build
-
 workflows:
   version: 2
   fluence:
     jobs:
       - sbt all tests
-#      - sbt integration tests
 #      - cli
       - smart contract
       - deploy scripts
       - js sdk
       - backend sdk
-#      - fluence book
 

--- a/build.sbt
+++ b/build.sbt
@@ -232,7 +232,7 @@ lazy val `swarm` = (project in file("effects/swarm"))
       scodecCore,
       web3jCrypto,
       cryptoHashsign,
-      scalaTest % Test,
+      scalaTest,
       bouncyCastleOld
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -233,7 +233,10 @@ lazy val `swarm` = (project in file("effects/swarm"))
       web3jCrypto,
       cryptoHashsign,
       scalaTest,
-      bouncyCastleOld
+    ),
+    dependencyOverrides ++= Seq(
+      // Using bouncycastle 1.60, so there's no clashing between project-wide 1.61 and web3j'a 1.60
+      bouncyCastle160
     )
   )
   .dependsOn(`ca-store`, `sttpEitherT` % "test->test;compile->compile")

--- a/build.sbt
+++ b/build.sbt
@@ -232,7 +232,8 @@ lazy val `swarm` = (project in file("effects/swarm"))
       scodecCore,
       web3jCrypto,
       cryptoHashsign,
-      scalaTest
+      scalaTest % Test,
+      bouncyCastleOld
     )
   )
   .dependsOn(`ca-store`, `sttpEitherT` % "test->test;compile->compile")

--- a/project/SbtCommons.scala
+++ b/project/SbtCommons.scala
@@ -13,6 +13,8 @@ object SbtCommons {
 
   val scalaV = scalaVersion := "2.12.8"
 
+  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.61"
+
   val commons = Seq(
     scalaV,
     version                              := "0.2.0",
@@ -29,7 +31,7 @@ object SbtCommons {
     scalafmtOnCompile := true,
     // see good explanation https://gist.github.com/djspiewak/7a81a395c461fd3a09a6941d4cd040f2
     scalacOptions ++= Seq("-Ypartial-unification", "-deprecation"),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0")
   )
 
   val kindProjector = Seq(
@@ -148,7 +150,6 @@ object SbtCommons {
 
   val asyncHttpClient = "org.asynchttpclient" % "async-http-client" % "2.8.1"
 
-  val bouncyCastle = "org.bouncycastle"    % "bcprov-jdk15on" % "1.61"
   val bouncyCastleOld = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"
 
   /* Test deps*/

--- a/project/SbtCommons.scala
+++ b/project/SbtCommons.scala
@@ -138,7 +138,7 @@ object SbtCommons {
   val scodecBits = "org.scodec" %% "scodec-bits" % "1.1.9"
   val scodecCore = "org.scodec" %% "scodec-core" % "1.11.3"
 
-  val web3jVersion = "4.3.0"
+  val web3jVersion = "4.2.0"
   val web3jCrypto = "org.web3j" % "crypto" % web3jVersion
   val web3jCore = "org.web3j"   % "core"   % web3jVersion
 

--- a/project/SbtCommons.scala
+++ b/project/SbtCommons.scala
@@ -13,8 +13,6 @@ object SbtCommons {
 
   val scalaV = scalaVersion := "2.12.8"
 
-  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"
-
   val commons = Seq(
     scalaV,
     version                              := "0.2.0",
@@ -32,7 +30,6 @@ object SbtCommons {
     // see good explanation https://gist.github.com/djspiewak/7a81a395c461fd3a09a6941d4cd040f2
     scalacOptions ++= Seq("-Ypartial-unification", "-deprecation"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
-    dependencyOverrides += bouncyCastle
   )
 
   val kindProjector = Seq(
@@ -150,6 +147,9 @@ object SbtCommons {
   val protobufUtil = "com.google.protobuf" % "protobuf-java-util" % "3.7.1"
 
   val asyncHttpClient = "org.asynchttpclient" % "async-http-client" % "2.8.1"
+
+  val bouncyCastle = "org.bouncycastle"    % "bcprov-jdk15on" % "1.61"
+  val bouncyCastleOld = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"
 
   /* Test deps*/
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8"     % Test

--- a/project/SbtCommons.scala
+++ b/project/SbtCommons.scala
@@ -13,8 +13,6 @@ object SbtCommons {
 
   val scalaV = scalaVersion := "2.12.8"
 
-  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.61"
-
   val commons = Seq(
     scalaV,
     version                              := "0.2.0",
@@ -150,7 +148,8 @@ object SbtCommons {
 
   val asyncHttpClient = "org.asynchttpclient" % "async-http-client" % "2.8.1"
 
-  val bouncyCastleOld = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"
+  val bouncyCastle = "org.bouncycastle"    % "bcprov-jdk15on" % "1.61"
+  val bouncyCastle160 = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"
 
   /* Test deps*/
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8"     % Test

--- a/project/SbtCommons.scala
+++ b/project/SbtCommons.scala
@@ -13,6 +13,8 @@ object SbtCommons {
 
   val scalaV = scalaVersion := "2.12.8"
 
+  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.61"
+
   val commons = Seq(
     scalaV,
     version                              := "0.2.0",
@@ -29,7 +31,8 @@ object SbtCommons {
     scalafmtOnCompile := true,
     // see good explanation https://gist.github.com/djspiewak/7a81a395c461fd3a09a6941d4cd040f2
     scalacOptions ++= Seq("-Ypartial-unification", "-deprecation"),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0")
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
+    dependencyOverrides += bouncyCastle
   )
 
   val kindProjector = Seq(
@@ -135,7 +138,7 @@ object SbtCommons {
   val scodecBits = "org.scodec" %% "scodec-bits" % "1.1.9"
   val scodecCore = "org.scodec" %% "scodec-core" % "1.11.3"
 
-  val web3jVersion = "4.2.0"
+  val web3jVersion = "4.3.0"
   val web3jCrypto = "org.web3j" % "crypto" % web3jVersion
   val web3jCore = "org.web3j"   % "core"   % web3jVersion
 
@@ -145,8 +148,6 @@ object SbtCommons {
 
   val protobuf = "io.github.scalapb-json"  %% "scalapb-circe"     % "0.4.3"
   val protobufUtil = "com.google.protobuf" % "protobuf-java-util" % "3.7.1"
-
-  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.61"
 
   val asyncHttpClient = "org.asynchttpclient" % "async-http-client" % "2.8.1"
 

--- a/project/SbtCommons.scala
+++ b/project/SbtCommons.scala
@@ -13,7 +13,7 @@ object SbtCommons {
 
   val scalaV = scalaVersion := "2.12.8"
 
-  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.61"
+  val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"
 
   val commons = Seq(
     scalaV,


### PR DESCRIPTION
Fixes `java.lang.ClassCastException: org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey cannot be cast to org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey` error in tests. 

The cause was that web3j uses 1.60, and we were using 1.61.