### PR TITLE
Use node_key for Kademlia keys

### DIFF
--- a/effects/swarm/src/test/scala/fluence/effects/swarm/SwarmClientIntegrationSpec.scala
+++ b/effects/swarm/src/test/scala/fluence/effects/swarm/SwarmClientIntegrationSpec.scala
@@ -41,8 +41,8 @@ import scala.util.Random
 @Ignore
 class SwarmClientIntegrationSpec extends FlatSpec with Matchers with EitherValues {
 
-  val randomKeys: ECKeyPair = Keys.createEcKeyPair()
-  val signer: Signer[ByteVector, ByteVector] = Secp256k1Signer.signer(randomKeys)
+  lazy val randomKeys: ECKeyPair = Keys.createEcKeyPair()
+  lazy val signer: Signer[ByteVector, ByteVector] = Secp256k1Signer.signer(randomKeys)
 
   private implicit val ioTimer: Timer[IO] = IO.timer(global)
   private implicit val ioShift: ContextShift[IO] = IO.contextShift(global)

--- a/node/src/main/scala/fluence/node/config/Configuration.scala
+++ b/node/src/main/scala/fluence/node/config/Configuration.scala
@@ -185,7 +185,7 @@ object Configuration {
             rootPath
               .resolve("tendermint")
               .resolve("config")
-              .resolve("priv_validator_key.json")
+              .resolve("node_key.json")
           )
         )
       )

--- a/node/src/main/scala/fluence/node/config/Configuration.scala
+++ b/node/src/main/scala/fluence/node/config/Configuration.scala
@@ -174,7 +174,7 @@ object Configuration {
     } yield ()
 
   /**
-   * Reads KeyPair from priv_validator_key.json file in tendermint path.
+   * Reads KeyPair from node_key.json file in tendermint path.
    *
    */
   def readTendermintKeyPair(rootPath: Path): IO[KeyPair] = {


### PR DESCRIPTION
After this fix, Kademlia's Public Key should match the Tendermint key stored in Fluence Contract.