### PR TITLE
`expectsEth` flag in `WasmVm`

### DIFF
--- a/node/src/test/scala/fluence/node/ControlRpcSpec.scala
+++ b/node/src/test/scala/fluence/node/ControlRpcSpec.scala
@@ -37,7 +37,7 @@ import fluence.effects.sttp.SttpEffect
 import fluence.effects.tendermint.block.history.Receipt
 import fluence.log.{Log, LogFactory}
 import fluence.node.workers.control.ControlRpc
-import fluence.statemachine.control.ControlServer
+import fluence.statemachine.control.{ControlServer, ControlStatus}
 import fluence.statemachine.control.signals.DropPeer
 import org.scalatest.{Matchers, OptionValues, WordSpec}
 import scodec.bits.ByteVector
@@ -54,7 +54,7 @@ class ControlRpcSpec extends WordSpec with Matchers with OptionValues {
     implicit val log: Log[IO] = LogFactory[IO].init(getClass.getSimpleName).unsafeRunSync()
 
     val config = ControlServer.Config("localhost", 26652)
-    val serverR = ControlServer.make[IO](config)
+    val serverR = ControlServer.make[IO](config, IO(ControlStatus(false)))
 
     val resources = for {
       server <- serverR

--- a/statemachine/control/src/test/scala/fluence/statemachine/control/ControlServerSpec.scala
+++ b/statemachine/control/src/test/scala/fluence/statemachine/control/ControlServerSpec.scala
@@ -53,7 +53,7 @@ class ControlServerSpec extends WordSpec with Matchers with ControlServerOps {
     implicit val logFactory = LogFactory.forPrintln[IO]()
     implicit val log: Log[IO] = LogFactory[IO].init(getClass.getSimpleName, level = Log.Error).unsafeRunSync()
 
-    val server = ControlServer.make[IO](config)
+    val server = ControlServer.make[IO](config, IO(ControlStatus(false)))
     val sttp = SttpEffect.plainResource[IO]
     val resources = server.flatMap(srv => sttp.map(srv -> _))
 

--- a/statemachine/src/test/scala/fluence/statemachine/StatemachineIntegrationSpec.scala
+++ b/statemachine/src/test/scala/fluence/statemachine/StatemachineIntegrationSpec.scala
@@ -19,6 +19,7 @@ package fluence.statemachine
 import java.nio.ByteBuffer
 
 import cats.data.EitherT
+import cats.effect.concurrent.Deferred
 import cats.effect.{ContextShift, IO, Timer}
 import com.github.jtendermint.jabci.types.{RequestCheckTx, RequestCommit, RequestDeliverTx, RequestQuery}
 import com.google.protobuf.ByteString
@@ -27,7 +28,7 @@ import fluence.effects.sttp.{SttpEffect, SttpStreamEffect}
 import fluence.effects.tendermint.rpc.http.{TendermintHttpRpc, TendermintHttpRpcImpl}
 import fluence.log.{Log, LogFactory}
 import fluence.statemachine.config.{StateMachineConfig, TendermintRpcConfig}
-import fluence.statemachine.control.ControlServer
+import fluence.statemachine.control.{ControlServer, ControlStatus}
 import fluence.statemachine.control.signals.{ControlSignals, MockedControlSignals}
 import fluence.statemachine.data.{QueryCode, TxCode}
 import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
@@ -60,7 +61,7 @@ class StatemachineIntegrationSpec extends WordSpec with Matchers with OneInstanc
   private val signals: ControlSignals[IO] = new MockedControlSignals
 
   val abciHandler: AbciHandler[IO] = ServerRunner
-    .buildAbciHandler(config, signals)
+    .buildAbciHandler(config, Deferred.unsafe[IO, ControlStatus], signals)
     .valueOr(e => throw new RuntimeException(e.message))
     .unsafeRunSync()
 

--- a/vm/src/main/scala/fluence/vm/AsmbleWasmVm.scala
+++ b/vm/src/main/scala/fluence/vm/AsmbleWasmVm.scala
@@ -47,6 +47,7 @@ class AsmbleWasmVm(
   private val sideModules: Seq[WasmModule],
   private val hasher: Hasher[Array[Byte], Array[Byte]]
 ) extends WasmVm {
+  override val expectsEth: Boolean = mainModule.expectsEth
 
   // size in bytes of pointer type in Wasm VM (can be different after Wasm64 release)
   private val WasmPointerSize = 4

--- a/vm/src/main/scala/fluence/vm/WasmVm.scala
+++ b/vm/src/main/scala/fluence/vm/WasmVm.scala
@@ -76,6 +76,12 @@ trait WasmVm {
    */
   def getVmState[F[_]: LiftIO: Monad]: EitherT[F, GetVmStateError, ByteVector]
 
+  /**
+   * Temporary way to pass a flag from userland (the WASM file) to the Node, denotes whether an app
+   * expects outer world to pass Ethereum blocks data into it.
+   * TODO move this flag to the Smart Contract
+   */
+  val expectsEth: Boolean
 }
 
 object WasmVm {

--- a/vm/src/main/scala/fluence/vm/wasm/module/MainWasmModule.scala
+++ b/vm/src/main/scala/fluence/vm/wasm/module/MainWasmModule.scala
@@ -28,6 +28,7 @@ import fluence.vm.VmError.{InternalVmError, NoSuchFnError, VmMemoryError}
 import fluence.vm.wasm._
 import fluence.vm.utils.safelyRunThrowable
 
+import scala.annotation.tailrec
 import scala.language.higherKinds
 
 /**
@@ -45,7 +46,8 @@ class MainWasmModule(
   private val module: WasmModule,
   private val allocateFunction: WasmFunction,
   private val deallocateFunction: WasmFunction,
-  private val invokeFunction: WasmFunction
+  private val invokeFunction: WasmFunction,
+  val expectsEth: Boolean
 ) {
 
   def computeStateHash[F[_]: Monad](): EitherT[F, GetVmStateError, Array[Byte]] =
@@ -143,31 +145,48 @@ object MainWasmModule {
     memoryHasher: MemoryHasher.Builder[F],
     allocationFunctionName: String,
     deallocationFunctionName: String,
-    invokeFunctionName: String
+    invokeFunctionName: String,
+    expectsEthFunctionName: String = "expects_eth"
   ): EitherT[F, ApplyError, MainWasmModule] =
     for {
       module ← WasmModule(moduleDescription, scriptContext, memoryHasher)
 
-      moduleMethods: Stream[WasmFunction] = moduleDescription.getCls.getDeclaredMethods.toStream
+      moduleMethods = moduleDescription.getCls.getDeclaredMethods.toStream
         .filter(method ⇒ Modifier.isPublic(method.getModifiers))
         .map(method ⇒ WasmFunction(method.getName, method))
+        .scanLeft((Option.empty[WasmFunction], Option.empty[WasmFunction], Option.empty[WasmFunction], false)) {
+          case (acc, m @ WasmFunction(`allocationFunctionName`, _)) ⇒
+            acc.copy(_1 = Some(m))
+          case (acc, m @ WasmFunction(`deallocationFunctionName`, _)) ⇒
+            acc.copy(_2 = Some(m))
+          case (acc, m @ WasmFunction(`invokeFunctionName`, _)) ⇒
+            acc.copy(_3 = Some(m))
+          case (acc, WasmFunction(`expectsEthFunctionName`, _)) ⇒
+            acc.copy(_4 = true)
+          case (acc, _) ⇒
+            acc
+        }
+        .collect {
+          case (Some(allocMethod), Some(deallocMethod), Some(invokeMethod), expectsEth) ⇒
+            (allocMethod, deallocMethod, invokeMethod, expectsEth)
+        }
 
-      (allocMethod, deallocMethod, invokeMethod) ← EitherT.fromOption(
-        moduleMethods
-          .scanLeft((Option.empty[WasmFunction], Option.empty[WasmFunction], Option.empty[WasmFunction])) {
-            case (acc, m @ WasmFunction(`allocationFunctionName`, _)) ⇒
-              acc.copy(_1 = Some(m))
-            case (acc, m @ WasmFunction(`deallocationFunctionName`, _)) ⇒
-              acc.copy(_2 = Some(m))
-            case (acc, m @ WasmFunction(`invokeFunctionName`, _)) ⇒
-              acc.copy(_3 = Some(m))
-            case (acc, _) ⇒
-              acc
-          }
-          .collectFirst {
-            case (Some(allocMethod), Some(deallocMethod), Some(invokeMethod)) ⇒
-              (allocMethod, deallocMethod, invokeMethod)
-          },
+      (allocMethod, deallocMethod, invokeMethod, expectsEth) ← EitherT.fromOption(
+        {
+          // Breaks once expectsEth flag is set, or traverses the whole stream and returns the last item
+          @tailrec
+          def collectFirstOrTakeLast(
+            stream: Stream[(WasmFunction, WasmFunction, WasmFunction, Boolean)],
+            pick: Option[(WasmFunction, WasmFunction, WasmFunction, Boolean)] = None
+          ): Option[(WasmFunction, WasmFunction, WasmFunction, Boolean)] =
+            stream match {
+              case (h @ (_, _, _, true)) #:: _ ⇒ Some(h)
+              case h #:: tail ⇒ collectFirstOrTakeLast(tail, Some(h))
+              case _ ⇒ pick
+            }
+
+          collectFirstOrTakeLast(moduleMethods)
+        },
         NoSuchFnError(
           s"The main module must have functions with names $allocationFunctionName, $deallocationFunctionName, $invokeFunctionName"
         ): ApplyError
@@ -177,7 +196,8 @@ object MainWasmModule {
       module,
       allocMethod,
       deallocMethod,
-      invokeMethod
+      invokeMethod,
+      expectsEth
     )
 
 }


### PR DESCRIPTION
A temporary solution to let users configure their ethereum expectations via WASM bytecode: to set the flag, just export `expects_eth` method from the module.