### PR TITLE
Add strict timeout to Eventually

### DIFF
--- a/effects/tendermint-rpc/src/test/scala/fluence/Eventually.scala
+++ b/effects/tendermint-rpc/src/test/scala/fluence/Eventually.scala
@@ -17,7 +17,9 @@
 package fluence
 
 import cats.effect._
+import cats.instances.either._
 import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.monadError._
 import org.scalactic.source.Position
@@ -42,8 +44,7 @@ trait Eventually {
       .timeout(
         fs2.Stream
           .awakeEvery[F](period)
-          // TODO: maybe limit every `p` with timeout of `period`? i.e., `Concurrent.timeout(p, period).attempt`
-          .evalMap(_ => p.attempt)
+          .evalMap(_ => Concurrent.timeout(p.attempt, period).attempt.map(_.flatten))
           .takeThrough(_.isLeft) // until p returns Right(Unit)
           .compile
           .last,

--- a/effects/tendermint-rpc/src/test/scala/fluence/effects/tendermint/rpc/WebsocketRpcSpec.scala
+++ b/effects/tendermint-rpc/src/test/scala/fluence/effects/tendermint/rpc/WebsocketRpcSpec.scala
@@ -20,14 +20,14 @@ import cats.effect._
 import cats.syntax.flatMap._
 import fluence.effects.sttp.{SttpEffect, SttpStreamEffect}
 import fluence.log.{Log, LogFactory}
-import fluence.Eventually
+import fluence.Timed
 import org.http4s.websocket.WebSocketFrame.Text
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.higherKinds
 
-class WebsocketRpcSpec extends WordSpec with Matchers with Eventually {
+class WebsocketRpcSpec extends WordSpec with Matchers with Timed {
   implicit private val ioTimer: Timer[IO] = IO.timer(global)
   implicit private val ioShift: ContextShift[IO] = IO.contextShift(global)
 
@@ -51,7 +51,7 @@ class WebsocketRpcSpec extends WordSpec with Matchers with Eventually {
     def block(height: Long) = Text(TestData.block(height))
 
     "subscribe and receive messages" in {
-      eventually[IO](resourcesF.use {
+      timed[IO](resourcesF.use {
         case (server, events) =>
           for {
             _ <- server.send(block(1))
@@ -72,7 +72,7 @@ class WebsocketRpcSpec extends WordSpec with Matchers with Eventually {
     "receive message after reconnect" in {
       val height = 1L
 
-      eventually[IO](resourcesF.use {
+      timed[IO](resourcesF.use {
         case (server, events) =>
           for {
             _ <- events.compile.drain
@@ -91,7 +91,7 @@ class WebsocketRpcSpec extends WordSpec with Matchers with Eventually {
       val incorrectMsg = "incorrect"
       val height = 1L
 
-      eventually[IO](resourcesF.use {
+      timed[IO](resourcesF.use {
         case (server, events) =>
           for {
             _ <- server.send(Text(incorrectMsg))

--- a/node/src/it/scala/fluence/node/MasterNodeIntegrationSpec.scala
+++ b/node/src/it/scala/fluence/node/MasterNodeIntegrationSpec.scala
@@ -19,6 +19,7 @@ package fluence.node
 import java.nio.ByteBuffer
 
 import cats.effect._
+import cats.syntax.apply._
 import com.softwaremill.sttp.asynchttpclient.fs2.AsyncHttpClientFs2Backend
 import com.softwaremill.sttp.circe.asJson
 import com.softwaremill.sttp.{SttpBackend, _}
@@ -98,8 +99,10 @@ class MasterNodeIntegrationSpec
       master1 <- runMaster(master1Port, "master1", n = 1)
       master2 <- runMaster(master2Port, "master2", n = 2)
 
-      _ <- Resource liftF eventually[IO](checkMasterRunning(master1Port), maxWait = 30.seconds) // TODO: 30 seconds is a bit too much for startup
-      _ <- Resource liftF eventually[IO](checkMasterRunning(master1Port), maxWait = 30.seconds) // TODO: investigate and reduce timeout
+      _ <- Resource liftF eventually[IO](
+        checkMasterRunning(master1Port) *> checkMasterRunning(master2Port),
+        maxWait = 45.seconds
+      ) // TODO: 45 seconds is a bit too much for startup; investigate and reduce timeout
 
     } yield Seq(master1, master2)
   }

--- a/node/src/it/scala/fluence/node/MasterNodeIntegrationSpec.scala
+++ b/node/src/it/scala/fluence/node/MasterNodeIntegrationSpec.scala
@@ -29,7 +29,7 @@ import fluence.node.status.MasterStatus
 import fluence.node.workers.status.WorkerStatus
 import org.scalatest.{Timer => _, _}
 import eth.FluenceContractTestOps._
-import fluence.Eventually
+import fluence.Timed
 import fluence.log.{Log, LogFactory}
 import fluence.node.config.FluenceContractConfig
 
@@ -46,7 +46,7 @@ import scala.util.Try
  * - Successful cluster formation and starting blocks creation
  */
 class MasterNodeIntegrationSpec
-    extends WordSpec with Matchers with BeforeAndAfterAll with OptionValues with Eventually with TendermintSetup
+    extends WordSpec with Matchers with BeforeAndAfterAll with OptionValues with Timed with TendermintSetup
     with GanacheSetup with DockerSetup {
 
   type Sttp = SttpBackend[IO, fs2.Stream[IO, ByteBuffer]]

--- a/node/src/it/scala/fluence/node/MasterNodeSpec.scala
+++ b/node/src/it/scala/fluence/node/MasterNodeSpec.scala
@@ -29,7 +29,7 @@ import cats.syntax.functor._
 import com.softwaremill.sttp.circe.asJson
 import com.softwaremill.sttp._
 import fluence.codec.PureCodec
-import fluence.Eventually
+import fluence.Timed
 import fluence.crypto.eddsa.Ed25519
 import fluence.effects.{Backoff, EffectError}
 import fluence.effects.ethclient.EthClient
@@ -55,7 +55,7 @@ import scala.concurrent.duration._
 import scala.language.higherKinds
 
 class MasterNodeSpec
-    extends WordSpec with Matchers with BeforeAndAfterAll with OptionValues with Eventually with GanacheSetup {
+    extends WordSpec with Matchers with BeforeAndAfterAll with OptionValues with Timed with GanacheSetup {
 
   implicit private val ioTimer: Timer[IO] = IO.timer(global)
   implicit private val ioShift: ContextShift[IO] = IO.contextShift(global)

--- a/node/src/test/scala/fluence/node/BlockUploadingSpec.scala
+++ b/node/src/test/scala/fluence/node/BlockUploadingSpec.scala
@@ -24,7 +24,7 @@ import cats.effect.concurrent.Ref
 import cats.effect.{IO, Resource}
 import cats.syntax.functor._
 import cats.syntax.apply._
-import fluence.Eventually
+import fluence.Timed
 import fluence.effects.castore.StoreError
 import fluence.effects.docker.params.{DockerImage, DockerLimits}
 import fluence.effects.ipfs.{IpfsData, IpfsUploader}
@@ -56,7 +56,7 @@ import scala.compat.Platform.currentTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-class BlockUploadingSpec extends WordSpec with Matchers with Eventually with OptionValues {
+class BlockUploadingSpec extends WordSpec with Matchers with Timed with OptionValues {
   implicit private val timer = IO.timer(global)
   implicit private val shift = IO.contextShift(global)
   implicit private val log = LogFactory.forPrintln[IO]().init("block uploading spec", level = Log.Warn).unsafeRunSync()

--- a/node/testkit/src/test/scala/fluence/node/BlockUploadingIntegrationSpec.scala
+++ b/node/testkit/src/test/scala/fluence/node/BlockUploadingIntegrationSpec.scala
@@ -53,7 +53,7 @@ import fluence.statemachine.error.StateMachineError
 import fluence.statemachine.state.{MachineState, StateService}
 import fluence.statemachine.vm.VmOperationInvoker
 import fluence.vm.InvocationResult
-import fluence.Eventually
+import fluence.Timed
 import fluence.statemachine.api.command.{PeersControl, ReceiptBus}
 import fluence.statemachine.api.tx.{Tx, TxCode, TxResponse}
 import fluence.statemachine.receiptbus.ReceiptBusBackend
@@ -68,7 +68,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.higherKinds
 
-class BlockUploadingIntegrationSpec extends WordSpec with Eventually with Matchers with OptionValues with EitherValues {
+class BlockUploadingIntegrationSpec extends WordSpec with Timed with Matchers with OptionValues with EitherValues {
   implicit private val timer = IO.timer(global)
   implicit private val shift = IO.contextShift(global)
   implicit private val log = LogFactory.forPrintln[IO]().init("block uploading spec", level = Log.Error).unsafeRunSync()

--- a/node/testkit/src/test/scala/fluence/node/PerBlockTxExecutorSpec.scala
+++ b/node/testkit/src/test/scala/fluence/node/PerBlockTxExecutorSpec.scala
@@ -24,7 +24,7 @@ import cats.syntax.functor._
 import cats.syntax.monad._
 import cats.syntax.traverse._
 import cats.instances.list._
-import fluence.Eventually
+import fluence.Timed
 import fluence.effects.tendermint.rpc.TestData
 import fluence.effects.tendermint.block.data.Block
 import fluence.log.LogFactory.Aux
@@ -40,7 +40,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.higherKinds
 
-class PerBlockTxExecutorSpec extends WordSpec with Eventually with Matchers with OptionValues with EitherValues {
+class PerBlockTxExecutorSpec extends WordSpec with Timed with Matchers with OptionValues with EitherValues {
 
   implicit private val ioTimer: Timer[IO] = IO.timer(global)
   implicit private val ioShift: ContextShift[IO] = IO.contextShift(global)

--- a/node/testkit/src/test/scala/fluence/node/ResponseSubscriberSpec.scala
+++ b/node/testkit/src/test/scala/fluence/node/ResponseSubscriberSpec.scala
@@ -21,7 +21,7 @@ import java.nio.file.Paths
 
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.{Monad, Parallel}
-import fluence.Eventually
+import fluence.Timed
 import fluence.effects.docker.params.{DockerImage, DockerLimits}
 import fluence.effects.tendermint.rpc.TestData
 import fluence.effects.tendermint.block.data.Block
@@ -42,7 +42,7 @@ import scala.concurrent.duration._
 import scala.language.higherKinds
 
 class ResponseSubscriberSpec
-    extends WordSpec with Matchers with BeforeAndAfterAll with Eventually with OptionValues with EitherValues {
+    extends WordSpec with Matchers with BeforeAndAfterAll with Timed with OptionValues with EitherValues {
 
   implicit private val ioTimer: Timer[IO] = IO.timer(global)
   implicit private val ioShift: ContextShift[IO] = IO.contextShift(global)

--- a/node/testkit/src/test/scala/fluence/node/WebsocketApiSpec.scala
+++ b/node/testkit/src/test/scala/fluence/node/WebsocketApiSpec.scala
@@ -18,7 +18,7 @@ package fluence.node
 
 import cats.effect.concurrent.Ref
 import cats.effect.{ContextShift, IO, Timer}
-import fluence.Eventually
+import fluence.Timed
 import fluence.effects.tendermint.block.data.Header
 import fluence.effects.tendermint.rpc.http.{RpcBodyMalformed, RpcError}
 import fluence.log.{Log, LogFactory}
@@ -58,7 +58,7 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.higherKinds
 
-class WebsocketApiSpec extends WordSpec with Matchers with BeforeAndAfterAll with Eventually {
+class WebsocketApiSpec extends WordSpec with Matchers with BeforeAndAfterAll with Timed {
 
   import fluence.node.workers.api.websocket.WebsocketRequests.WebsocketRequest._
   import fluence.node.workers.api.websocket.WebsocketResponses.WebsocketResponse._


### PR DESCRIPTION
Previously, `eventually` would hang if passed task hangs. Now it would stop with timeout exception after `maxWait` no matter what.

Also, now `eventually` would stop running task after specified `period`.