### PR TITLE
Change bootstrap procedure & fix bugs in routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
 name = "arrayref"
@@ -1514,7 +1514,7 @@ checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 [[package]]
 name = "libp2p"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "bytes",
  "futures 0.3.5",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "quote",
  "syn",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "libp2p-deflate"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "flate2",
  "futures 0.3.5",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "base64 0.11.0",
  "byteorder 1.3.4",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "arrayvec 0.5.1",
  "bs58",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "async-std",
  "data-encoding",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "curve25519-dalek",
  "futures 0.3.5",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "bytes",
  "futures 0.3.5",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "log",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "aes-ctr",
  "ctr",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "js-sys",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "async-tls",
  "bytes",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2069,7 +2069,7 @@ checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.4",
+ "miow 0.3.5",
  "winapi 0.3.8",
 ]
 
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
  "winapi 0.3.8",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.8.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "bytes",
  "futures 0.3.5",
@@ -2305,9 +2305,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.57"
+version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#b7ec948326d37ae70a167e6efaad0ae2399ef826"
+source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
 dependencies = [
  "arrayref",
  "bs58",
@@ -2440,18 +2440,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a1acf4a3e70849f8a673497ef984f043f95d2d8252dcdf74d54e6a1e47e8a"
+checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194e88048b71a3e02eb4ee36a6995fed9b8236c11a7bb9f7247a9d9835b3f265"
+checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2490,9 +2490,9 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+checksum = "0afe1bd463b9e9ed51d0e0f0b50b6b146aec855c56fd182bb242388710a9b6de"
 
 [[package]]
 name = "proc-macro2"
@@ -2605,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 [[package]]
 name = "libp2p"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "bytes",
  "futures 0.3.5",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "quote",
  "syn",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "libp2p-deflate"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "flate2",
  "futures 0.3.5",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "base64 0.11.0",
  "byteorder 1.3.4",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "arrayvec 0.5.1",
  "bs58",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "async-std",
  "data-encoding",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "curve25519-dalek",
  "futures 0.3.5",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "bytes",
  "futures 0.3.5",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "log",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "aes-ctr",
  "ctr",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "js-sys",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "async-tls",
  "bytes",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.19.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 dependencies = [
  "adler32",
 ]
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.8.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "bytes",
  "futures 0.3.5",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.0"
-source = "git+https://github.com/fluencelabs/rust-libp2p#c36397b7de4c9c007ca7fe3a2098d82071ea446b"
+source = "git+https://github.com/fluencelabs/rust-libp2p#d7c19893401726132319a2b3289dbb105de488bb"
 dependencies = [
  "arrayref",
  "bs58",
@@ -3102,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
@@ -3343,9 +3343,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3679,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"

--- a/client/rust-libp2p/src/client.rs
+++ b/client/rust-libp2p/src/client.rs
@@ -41,6 +41,15 @@ impl Transport {
     pub fn is_network(&self) -> bool {
         matches!(self, Transport::Network)
     }
+
+    pub fn from_maddr(maddr: &Multiaddr) -> Self {
+        use parity_multiaddr::Protocol::Memory;
+        if maddr.iter().any(|p| matches!(p, Memory(_))) {
+            Transport::Memory
+        } else {
+            Transport::Network
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -11,6 +11,7 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:19999']
       - targets: ['localhost:29999']
+      - targets: ['localhost:39999']
 
 # histogram_quantile(0.95, sum(irate(kademlia_exporter_random_node_lookup_duration_bucket[10s])) by (le))
 # histogram_quantile(0.95, sum(rate(kademlia_exporter_ping_duration_bucket[5m])) by (le))

--- a/node_client.mk
+++ b/node_client.mk
@@ -1,7 +1,9 @@
 client:
 	cargo run -p fluence-client -- ${args}
 
-DEBUG_ENV=RUST_LOG="debug,tokio_threadpool=info,tokio_reactor=info,mio=info,tokio_io=info,soketto=info,yamux=info,multistream_select=info,libp2p_secio=info,libp2p_websocket::framed=info,libp2p_ping=info,libp2p_core::upgrade::apply=info,libp2p_kad::kbucket=info"
+LVL=warn
+LVL_VERBOSE=info
+DEBUG_ENV=RUST_LOG="info,libp2p_kad::query=${LVL_VERBOSE},fluence_server::bootstrapper=${LVL_VERBOSE},fluence_server::function::router=${LVL_VERBOSE},fluence_server::function::router_behaviour=${LVL},libp2p_swarm=${LVL},fluence_server=${LVL},tokio_threadpool=${LVL},tokio_reactor=${LVL},mio=${LVL},tokio_io=${LVL},soketto=${LVL},yamux=${LVL},multistream_select=${LVL},libp2p_secio=${LVL},libp2p_websocket::framed=${LVL},libp2p_ping=${LVL},libp2p_core::upgrade::apply=${LVL},libp2p_kad::kbucket=${LVL},libp2p_kad::behaviour=${LVL}"
 
 client-debug:
 	${DEBUG_ENV} cargo run -p fluence-client -- ${args}
@@ -103,5 +105,29 @@ client-many:
 	select-layout tiled \; \
 	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/9999/ws' \; \
 	select-layout tiled
+
+COUNT=25
+ULIMIT=ulimit -n 10000 &&
+INFO_ENV=${DEBUG_ENV}
+TEST_ENV=${INFO_ENV} HOST=127.0.0.1 ASYNC_STD_THREAD_COUNT=16 RUST_BACKTRACE=full COUNT=${COUNT}
+MULTIPLE_NODES=${TEST_ENV} cargo test --test run_multiple_nodes main -- --nocapture | tee -a "$(date)_node.log"
+
+massive-node:
+	tmux \
+    	new-session  '${ULIMIT} PORT=20000 ${MULTIPLE_NODES}' \; \
+    	select-layout tiled \; \
+    	split-window 'sleep 1 && ${ULIMIT} PORT=30000 BS_PORT=20000 ${MULTIPLE_NODES}' \; \
+    	select-layout tiled \; \
+    	split-window 'sleep 1 && ${ULIMIT} PORT=40000 BS_PORT=30000 ${MULTIPLE_NODES}' \; \
+    	select-layout tiled
+
+massive-clients:
+	tmux \
+    	new-session  '${CLIENT} /ip4/127.0.0.1/tcp/20002' \; \
+    	select-layout tiled \; \
+    	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/30003' \; \
+    	select-layout tiled \; \
+    	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/40004' \; \
+    	select-layout tiled
 
 .PHONY: client client-debug client-tmux node-tmux client-many node-many

--- a/node_client.mk
+++ b/node_client.mk
@@ -3,7 +3,7 @@ client:
 
 LVL=warn
 LVL_VERBOSE=info
-DEBUG_ENV=RUST_LOG="info,libp2p_kad::query=${LVL_VERBOSE},fluence_server::bootstrapper=${LVL_VERBOSE},fluence_server::function::router=${LVL_VERBOSE},fluence_server::function::router_behaviour=${LVL},libp2p_swarm=${LVL},fluence_server=${LVL},tokio_threadpool=${LVL},tokio_reactor=${LVL},mio=${LVL},tokio_io=${LVL},soketto=${LVL},yamux=${LVL},multistream_select=${LVL},libp2p_secio=${LVL},libp2p_websocket::framed=${LVL},libp2p_ping=${LVL},libp2p_core::upgrade::apply=${LVL},libp2p_kad::kbucket=${LVL},libp2p_kad::behaviour=${LVL}"
+DEBUG_ENV=RUST_LOG="${LVL_VERBOSE},libp2p_kad::query=${LVL_VERBOSE},fluence_server::bootstrapper=${LVL_VERBOSE},fluence_server::function::router=${LVL_VERBOSE},fluence_server::function::router_behaviour=${LVL_VERBOSE},libp2p_swarm=${LVL_VERBOSE},fluence_server=${LVL_VERBOSE},tokio_threadpool=${LVL},tokio_reactor=${LVL},mio=${LVL},tokio_io=${LVL},soketto=${LVL},yamux=${LVL},multistream_select=${LVL},libp2p_secio=${LVL},libp2p_websocket::framed=${LVL},libp2p_ping=${LVL},libp2p_core::upgrade::apply=${LVL},libp2p_kad::kbucket=${LVL},libp2p_kad::behaviour=${LVL}"
 
 client-debug:
 	${DEBUG_ENV} cargo run -p fluence-client -- ${args}
@@ -106,11 +106,11 @@ client-many:
 	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/9999/ws' \; \
 	select-layout tiled
 
-COUNT=25
+COUNT=15
 ULIMIT=ulimit -n 10000 &&
 INFO_ENV=${DEBUG_ENV}
 TEST_ENV=${INFO_ENV} HOST=127.0.0.1 ASYNC_STD_THREAD_COUNT=16 RUST_BACKTRACE=full COUNT=${COUNT}
-MULTIPLE_NODES=${TEST_ENV} cargo test --test run_multiple_nodes main -- --nocapture | tee -a "$(date)_node.log"
+MULTIPLE_NODES=${TEST_ENV} cargo test --release --test run_multiple_nodes main -- --nocapture | tee -a "$(date)_node.log"
 
 massive-node:
 	tmux \
@@ -121,13 +121,14 @@ massive-node:
     	split-window 'sleep 1 && ${ULIMIT} PORT=40000 BS_PORT=30000 ${MULTIPLE_NODES}' \; \
     	select-layout tiled
 
+RND=`printf '%02d' $$(( RANDOM % ${COUNT} ))`
 massive-clients:
 	tmux \
-    	new-session  '${CLIENT} /ip4/127.0.0.1/tcp/20002' \; \
+    	new-session  '${CLIENT} /ip4/127.0.0.1/tcp/200${RND}' \; \
     	select-layout tiled \; \
-    	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/30003' \; \
+    	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/300${RND}' \; \
     	select-layout tiled \; \
-    	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/40004' \; \
+    	split-window 'sleep 1 && ${CLIENT} /ip4/127.0.0.1/tcp/400${RND}' \; \
     	select-layout tiled
 
-.PHONY: client client-debug client-tmux node-tmux client-many node-many
+.PHONY: client client-debug client-tmux node-tmux client-many node-many try

--- a/server/src/behaviour/bootstrapper.rs
+++ b/server/src/behaviour/bootstrapper.rs
@@ -29,7 +29,7 @@ impl NetworkBehaviourEventProcess<BootstrapperEvent> for ServerBehaviour {
                 self.bootstrap()
             }
             BootstrapperEvent::ReconnectToBootstrap { multiaddr, error } => {
-                log::info!(
+                log::debug!(
                     "Bootstrap disconnected {} {}, reconnecting",
                     multiaddr,
                     error.unwrap_or_default()

--- a/server/src/behaviour/bootstrapper.rs
+++ b/server/src/behaviour/bootstrapper.rs
@@ -28,20 +28,13 @@ impl NetworkBehaviourEventProcess<BootstrapperEvent> for ServerBehaviour {
                 // TODO: refactor out "thin bootstrap": only look ourselves in kademlia
                 self.bootstrap()
             }
-            BootstrapperEvent::ReconnectToBootstrap {
-                peer_id,
-                multiaddr,
-                error,
-            } => {
+            BootstrapperEvent::ReconnectToBootstrap { multiaddr, error } => {
                 log::info!(
                     "Bootstrap disconnected {} {}, reconnecting",
-                    peer_id.as_ref().map(|p| p.to_string()).unwrap_or_default(),
+                    multiaddr,
                     error.unwrap_or_default()
                 );
                 self.dial(multiaddr);
-                if let Some(peer_id) = peer_id {
-                    self.dial_peer(peer_id)
-                }
             }
         }
     }

--- a/server/src/behaviour/identify.rs
+++ b/server/src/behaviour/identify.rs
@@ -56,7 +56,7 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for ServerBehaviour {
 
             // TODO: handle error?
             IdentifyEvent::Error { error, peer_id } => {
-                log::error!("Identify error on {}: {}", peer_id, error);
+                log::debug!("Identify error on {}: {}", peer_id, error);
             }
 
             // We don't care about Sent identification info

--- a/server/src/behaviour/server_behaviour.rs
+++ b/server/src/behaviour/server_behaviour.rs
@@ -53,7 +53,8 @@ impl ServerBehaviour {
         bootstrap_nodes: Vec<Multiaddr>,
         registry: Option<&Registry>,
     ) -> Self {
-        let config = RouterConfig::new(key_pair.clone(), local_peer_id, listening_addresses);
+        let config =
+            RouterConfig::new(key_pair.clone(), local_peer_id.clone(), listening_addresses);
         let router = FunctionRouter::new(config, trust_graph, registry);
         let local_public_key = PublicKey::Ed25519(key_pair.public());
         let identity = Identify::new(
@@ -62,7 +63,7 @@ impl ServerBehaviour {
             local_public_key,
         );
         let ping = Ping::new(PingConfig::new().with_keep_alive(false));
-        let bootstrapper = Bootstrapper::new(bootstrap_nodes);
+        let bootstrapper = Bootstrapper::new(local_peer_id, bootstrap_nodes);
 
         Self {
             router,

--- a/server/src/behaviour/server_behaviour.rs
+++ b/server/src/behaviour/server_behaviour.rs
@@ -94,14 +94,6 @@ impl ServerBehaviour {
             .push_back(libp2p::swarm::NetworkBehaviourAction::DialAddress { address: maddr })
     }
 
-    pub(super) fn dial_peer(&mut self, peer_id: PeerId) {
-        self.events
-            .push_back(libp2p::swarm::NetworkBehaviourAction::DialPeer {
-                peer_id,
-                condition: libp2p::swarm::DialPeerCondition::Disconnected,
-            });
-    }
-
     event_polling!(custom_poll, events, SwarmEventType);
 }
 

--- a/server/src/bootstrapper/behaviour.rs
+++ b/server/src/bootstrapper/behaviour.rs
@@ -43,6 +43,7 @@ impl Backoff {
 }
 
 pub struct Bootstrapper {
+    peer_id: PeerId,
     pub bootstrap_nodes: HashSet<Multiaddr>,
     delayed_events: Vec<(Option<Instant>, SwarmEventType)>,
     events: VecDeque<SwarmEventType>,
@@ -51,8 +52,9 @@ pub struct Bootstrapper {
 }
 
 impl Bootstrapper {
-    pub fn new(bootstrap_nodes: Vec<Multiaddr>) -> Self {
+    pub fn new(peer_id: PeerId, bootstrap_nodes: Vec<Multiaddr>) -> Self {
         Self {
+            peer_id,
             bootstrap_nodes: bootstrap_nodes.into_iter().collect(),
             delayed_events: Default::default(),
             events: Default::default(),
@@ -159,7 +161,12 @@ impl NetworkBehaviour for Bootstrapper {
             ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr,
         };
 
-        log::debug!("connection established with {} {:?}", peer_id, maddr);
+        log::debug!(
+            "{} connection established with {} {:?}",
+            self.peer_id,
+            peer_id,
+            maddr
+        );
 
         if self.bootstrap_nodes.contains(maddr) {
             self.schedule_bootstrap();

--- a/server/src/bootstrapper/event.rs
+++ b/server/src/bootstrapper/event.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use libp2p::PeerId;
 use parity_multiaddr::Multiaddr;
 
 #[derive(Debug, Clone)]
@@ -23,7 +22,6 @@ pub enum BootstrapperEvent {
 
     // Command to reconnect to specified bootstrap
     ReconnectToBootstrap {
-        peer_id: Option<PeerId>,
         multiaddr: Multiaddr,
         error: Option<String>,
     },

--- a/server/src/function/peers.rs
+++ b/server/src/function/peers.rs
@@ -79,13 +79,14 @@ impl FunctionRouter {
         let calls = self.wait_peer.remove_with(&peer_id, |wp| wp.found());
         for call in calls {
             if peers.is_empty() || !peers.iter().any(|p| p == &peer_id) {
-                log::warn!(
+                let err_msg = format!(
                     "peer {} wasn't found via closest query: {:?}",
                     peer_id,
-                    peers
+                    peers.iter().map(|p| p.to_base58())
                 );
+                log::warn!("{}", err_msg);
                 // Peer wasn't found, send error
-                self.send_error_on_call(call.into(), "peer wasn't found via closest query".into())
+                self.send_error_on_call(call.into(), err_msg)
             } else {
                 // Forward calls to `peer_id`, guaranteeing it is now routable
                 self.send_to(

--- a/server/src/function/router.rs
+++ b/server/src/function/router.rs
@@ -143,7 +143,8 @@ impl FunctionRouter {
                     continue;
                 }
                 Peer(id) => {
-                    self.send_to(id.clone(), Unknown, call.with_target(target.collect()));
+                    let ctx = "send message to remote peer";
+                    self.send_to(id.clone(), Unknown, call.with_target(target.collect()), ctx);
                     return;
                 }
                 s @ Service(_) if is_local || self.service_available_locally(s) => {
@@ -165,9 +166,8 @@ impl FunctionRouter {
                     match target.next() {
                         Some(Signature(_)) => {
                             let target = Address::cons(client_protocol, target);
-                            // TODO: Why Routable? If it's a local client, it should be connected
-                            //       It can't be Routable, because it's not reachable via Kademlia
-                            self.send_to(client_id, Routable, call.with_target(target));
+                            let ctx = "send message to local client";
+                            self.send_to(client_id, Connected, call.with_target(target), ctx);
                         }
                         Some(other) => {
                             let path = target.join("");
@@ -202,7 +202,13 @@ impl FunctionRouter {
     }
 
     /// Schedule sending a call to unknown peer
-    pub(super) fn send_to(&mut self, to: PeerId, expected: PeerStatus, call: FunctionCall) {
+    pub(super) fn send_to(
+        &mut self,
+        to: PeerId,
+        expected: PeerStatus,
+        call: FunctionCall,
+        ctx: &str,
+    ) {
         use PeerStatus::*;
 
         let status = self.peer_status(&to);
@@ -211,7 +217,7 @@ impl FunctionRouter {
             // TODO: This error is not helpful. Example of helpful error: "Peer wasn't found via GetClosestPeers".
             //       Consider custom errors for different pairs of (status, expected)
             #[rustfmt::skip]
-            let err_msg = format!("Unexpected status for {}. Got {:?} expected {:?}", to, status, expected);
+            let err_msg = format!("Unexpected status for {}. Got {:?} expected {:?} ({})", to, status, expected, ctx);
             #[rustfmt::skip]
             log::error!("Can't send call {:?}: {}", call, err_msg);
             self.send_error_on_call(call, err_msg);
@@ -220,7 +226,7 @@ impl FunctionRouter {
 
         match status {
             Connected => self.send_to_connected(to, call),
-            Routable => self.connect_then_send(to, call),
+            Routable | CheckedRoutable => self.connect_then_send(to, call),
             Unknown => self.search_then_send(to, call),
         }
     }
@@ -296,7 +302,9 @@ impl FunctionRouter {
 
     /// Run kademlia bootstrap, to advertise ourselves in Kademlia
     pub fn bootstrap(&mut self) {
+        use std::borrow::Borrow;
+        // NOTE: Using Qm form of `peer_id` here (via peer_id.borrow), since kademlia uses that for keys
         self.kademlia
-            .get_closest_peers(self.config.peer_id.as_bytes());
+            .get_closest_peers(self.config.peer_id.borrow());
     }
 }

--- a/server/src/function/router.rs
+++ b/server/src/function/router.rs
@@ -296,9 +296,7 @@ impl FunctionRouter {
 
     /// Run kademlia bootstrap, to advertise ourselves in Kademlia
     pub fn bootstrap(&mut self) {
-        match self.kademlia.bootstrap() {
-            Err(err) => log::warn!("bootstrap failed: {:?}", err),
-            _ => {}
-        }
+        self.kademlia
+            .get_closest_peers(self.config.peer_id.as_bytes());
     }
 }

--- a/server/src/function/services.rs
+++ b/server/src/function/services.rs
@@ -119,7 +119,6 @@ impl FunctionRouter {
                         .map_or(provider.clone(), |target| provider.clone().extend(target)),
                 );
                 // TODO: write tests on that, it's a very complex decision
-                // call.target = Some(provider.clone());
                 log::debug!("Sending call to provider {:?}", call);
                 self.call(call);
             }

--- a/server/tests/run_multiple_nodes.rs
+++ b/server/tests/run_multiple_nodes.rs
@@ -31,7 +31,7 @@ use std::thread::sleep;
 mod utils;
 
 #[test]
-// #[ignore]
+#[ignore]
 fn main() {
     env_logger::init();
 

--- a/server/tests/run_multiple_nodes.rs
+++ b/server/tests/run_multiple_nodes.rs
@@ -16,22 +16,23 @@
 
 #![allow(unused_imports, dead_code)]
 
+use async_std::task;
 use fluence_client::Transport;
 use fluence_server::Server;
+use libp2p::core::multiaddr::{Multiaddr, Protocol};
 use prometheus::Registry;
+use rand::prelude::*;
+use std::env;
+use std::net::IpAddr;
 
 use crate::utils::*;
+use std::thread::sleep;
+
 mod utils;
 
 #[test]
 // #[ignore]
 fn main() {
-    use async_std::task;
-    use libp2p::core::multiaddr::{Multiaddr, Protocol};
-    use rand::prelude::*;
-    use std::env;
-    use std::net::IpAddr;
-
     env_logger::init();
 
     let count: usize = env::var("COUNT")
@@ -60,14 +61,23 @@ fn main() {
         .map(|s| s.parse().expect("bs correct"))
         .ok();
 
-    fn create_maddr(host: IpAddr, port: u16) -> Multiaddr {
-        let mut maddr = Multiaddr::from(host);
-        maddr.push(Protocol::Tcp(port));
-        maddr
-    }
-
     let registry = Registry::new();
 
+    start_bunch(count, port, host, bs_port, bs_max, Some(&registry));
+
+    log::info!("started /metrics at {}:{}", host, port - 1);
+    task::block_on(Server::start_metrics_endpoint(registry, (host, port - 1)))
+        .expect("Start /metrics endpoint");
+}
+
+fn start_bunch(
+    count: usize,
+    port: u16,
+    host: IpAddr,
+    bs_port: Option<u16>,
+    bs_max: usize,
+    registry: Option<&Registry>,
+) {
     let mut idx = 0;
     let mut rng = thread_rng();
     let external_bootstraps = bs_port.into_iter().flat_map(|p| {
@@ -81,7 +91,7 @@ fn main() {
         |bs, maddr| {
             let rnd = bs.into_iter().choose_multiple(&mut rng, bs_max);
             let bs: Vec<_> = rnd.into_iter().chain(external_bootstraps.clone()).collect();
-            create_swarm(bs, maddr, None, Transport::Network, Some(&registry))
+            create_swarm(bs, maddr, None, Transport::Network, registry)
         },
         || {
             let maddr = create_maddr(host, port + idx);
@@ -90,8 +100,64 @@ fn main() {
         },
         false,
     );
+}
 
-    log::info!("started /metrics at {}:{}", host, port - 1);
-    task::block_on(Server::start_metrics_endpoint(registry, (host, port - 1)))
-        .expect("Start /metrics endpoint");
+fn create_maddr(host: IpAddr, port: u16) -> Multiaddr {
+    let mut maddr = Multiaddr::from(host);
+    maddr.push(Protocol::Tcp(port));
+    maddr
+}
+
+#[test]
+fn receive_call_on_big_network() {
+    use rand::distributions::Alphanumeric;
+
+    let localhost = "127.0.0.1".parse().unwrap();
+    let count = 15;
+    start_bunch(count, 20000, localhost, None, count, None);
+    start_bunch(count, 30000, localhost, Some(20000), count, None);
+    start_bunch(count, 40000, localhost, Some(30000), count, None);
+
+    sleep(TIMEOUT * 2);
+
+    let mut rng = thread_rng();
+    let mut addr = |port| {
+        format!("/ip4/127.0.0.1/tcp/{}", rng.gen_range(port, port + count))
+            .parse()
+            .unwrap()
+    };
+
+    let mut i = 10;
+    while i > 0 {
+        i -= 1;
+
+        let service = thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(7)
+            .collect::<String>();
+        let service = service.as_str();
+
+        let mut client20 = ConnectedClient::connect_to(addr(20000)).expect("connect 20");
+        let client30 = ConnectedClient::connect_to(addr(30000)).expect("connect 30");
+        let client40 = ConnectedClient::connect_to(addr(40000)).expect("connect 40");
+
+        log::info!("\niteration {}", i);
+        log::info!("service: {}", service);
+        log::info!("client20: {}", client20.relay_address());
+        log::info!("client30: {}", client30.relay_address());
+        log::info!("client40: {}", client40.relay_address());
+
+        sleep(SHORT_TIMEOUT);
+
+        client20.send(provide_call(service, client20.relay_address()));
+        sleep(KAD_TIMEOUT);
+
+        client30.send(service_call(service, client30.relay_address()));
+        let call30to20 = client20.receive();
+        log::info!("call30to20: {:?}", call30to20);
+
+        client40.send(service_call(service, client40.relay_address()));
+        let call40to20 = client20.receive();
+        log::info!("call40to20: {:?}", call40to20);
+    }
 }

--- a/server/tests/run_multiple_nodes.rs
+++ b/server/tests/run_multiple_nodes.rs
@@ -24,7 +24,7 @@ use crate::utils::*;
 mod utils;
 
 #[test]
-#[ignore]
+// #[ignore]
 fn main() {
     use async_std::task;
     use libp2p::core::multiaddr::{Multiaddr, Protocol};

--- a/server/tests/utils/connected_client.rs
+++ b/server/tests/utils/connected_client.rs
@@ -36,7 +36,7 @@ impl ConnectedClient {
         use std::io::{Error, ErrorKind};
 
         let connect = async move {
-            let (mut client, _) = Client::connect_with(node_address.clone(), Transport::Memory)
+            let (mut client, _) = Client::connect_with(node_address.clone(), Transport::Network)
                 .await
                 .expect("sender connected");
             let result: Result<_, Error> = if let Some(ClientEvent::NewConnection {

--- a/server/tests/utils/connected_client.rs
+++ b/server/tests/utils/connected_client.rs
@@ -35,8 +35,9 @@ impl ConnectedClient {
         use core::result::Result;
         use std::io::{Error, ErrorKind};
 
+        let transport = Transport::from_maddr(&node_address);
         let connect = async move {
-            let (mut client, _) = Client::connect_with(node_address.clone(), Transport::Network)
+            let (mut client, _) = Client::connect_with(node_address.clone(), transport)
                 .await
                 .expect("sender connected");
             let result: Result<_, Error> = if let Some(ClientEvent::NewConnection {

--- a/server/tests/utils/misc.rs
+++ b/server/tests/utils/misc.rs
@@ -130,7 +130,7 @@ HFF3V9XXbhdTLWGVZkJYd9a7NyuD5BLWLdwc4EFBcCZa
 #[allow(dead_code)]
 // Enables logging, filtering out unnecessary details
 pub fn enable_logs() {
-    use log::LevelFilter::{Debug, Info, Warn};
+    use log::LevelFilter::{Debug, Info};
 
     env_logger::builder()
         .filter_level(Debug)
@@ -149,7 +149,6 @@ pub fn enable_logs() {
         .filter(Some("libp2p_kad::kbucket"), Info)
         .filter(Some("libp2p_plaintext"), Info)
         .filter(Some("libp2p_identify::protocol"), Info)
-        .filter(Some("libp2p_kad::behaviour"), Warn)
         .try_init()
         .ok();
 }

--- a/server/tests/utils/misc.rs
+++ b/server/tests/utils/misc.rs
@@ -130,7 +130,7 @@ HFF3V9XXbhdTLWGVZkJYd9a7NyuD5BLWLdwc4EFBcCZa
 #[allow(dead_code)]
 // Enables logging, filtering out unnecessary details
 pub fn enable_logs() {
-    use log::LevelFilter::{Debug, Info};
+    use log::LevelFilter::{Debug, Info, Warn};
 
     env_logger::builder()
         .filter_level(Debug)
@@ -149,6 +149,7 @@ pub fn enable_logs() {
         .filter(Some("libp2p_kad::kbucket"), Info)
         .filter(Some("libp2p_plaintext"), Info)
         .filter(Some("libp2p_identify::protocol"), Info)
+        .filter(Some("libp2p_kad::behaviour"), Warn)
         .try_init()
         .ok();
 }


### PR DESCRIPTION
- `FunctionRouter::bootstrap` now just calls `find_closest(self.local_peer_id)` instead of full maintenance procedure
- Add bootstrap reconnect backoff
- Disable bootstrap reconnect via peer_id: it was producing InvalidPeerId errors, and served no purpose
- Add `PeerStatus::CheckedRoutable` for when we know peer must be routable, but there's no way to check that (maybe will delete PeerStatus::Routable in future)
- Add `context` to `send_to` to improve error messages (though it's a rather ad-hoc way, redesign needed there)
- Fixed `get_closest_peers`: now search uses `Qm...` peer ids instead of `12D...` peer ids.

