### PR TITLE
Protocol config

### DIFF
--- a/client/rust-libp2p/src/client.rs
+++ b/client/rust-libp2p/src/client.rs
@@ -122,7 +122,7 @@ impl Client {
     ) -> Result<Swarm<ClientBehaviour>, Box<dyn Error>> {
         let mut swarm = {
             let key_pair = libp2p::identity::Keypair::Ed25519(self.key_pair.clone());
-            let behaviour = ClientBehaviour::default();
+            let behaviour = ClientBehaviour::new(key_pair.public().into_peer_id());
 
             macro_rules! swarm {
                 ($transport:expr) => {{

--- a/faas-api/src/lib.rs
+++ b/faas-api/src/lib.rs
@@ -40,3 +40,4 @@ pub use address::{Address, AddressError};
 pub use address_protocol::Protocol;
 pub use call::FunctionCall;
 pub use libp2p_protocol::message::ProtocolMessage;
+pub use libp2p_protocol::upgrade::ProtocolConfig;

--- a/server/src/function/router_behaviour.rs
+++ b/server/src/function/router_behaviour.rs
@@ -15,7 +15,7 @@
  */
 
 use super::{FunctionRouter, SwarmEventType};
-use faas_api::ProtocolMessage;
+use faas_api::{ProtocolConfig, ProtocolMessage};
 
 use std::error::Error;
 use std::task::{Context, Poll};
@@ -36,13 +36,14 @@ use libp2p::{
 
 impl NetworkBehaviour for FunctionRouter {
     type ProtocolsHandler = IntoProtocolsHandlerSelect<
-        OneShotHandler<ProtocolMessage, ProtocolMessage, ProtocolMessage>,
+        OneShotHandler<ProtocolConfig, ProtocolMessage, ProtocolMessage>,
         <Kademlia<MemoryStore> as NetworkBehaviour>::ProtocolsHandler,
     >;
     type OutEvent = ();
 
     fn new_handler(&mut self) -> Self::ProtocolsHandler {
-        IntoProtocolsHandler::select(Default::default(), self.kademlia.new_handler())
+        let config = ProtocolConfig::new(self.config.peer_id.clone());
+        IntoProtocolsHandler::select(config.into(), self.kademlia.new_handler())
     }
 
     fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {


### PR DESCRIPTION
Currently `ProtocolConfig::peer_id` is unused. It will be used in the following PR.