### PR TITLE
Route by hashtag

### DIFF
--- a/client/fluence-ipfs/src/lib.rs
+++ b/client/fluence-ipfs/src/lib.rs
@@ -42,12 +42,12 @@ use uuid::Uuid;
 
 const IPFS_SERVICE_ID: &str = "IPFS.multiaddr";
 #[rustfmt::skip]
-static IPFS_SERVICE: Lazy<Protocol> = Lazy::new(|| Protocol::Service(IPFS_SERVICE_ID.to_string()));
+static IPFS_SERVICE: Lazy<Protocol> = Lazy::new(|| Protocol::Providers(IPFS_SERVICE_ID.to_string()));
 
 fn register_call(client: PeerId, relay: PeerId, service_id: &str, kp: &Keypair) -> FunctionCall {
     let sender = relay!(relay, client, kp);
     let reply_to = Some(sender.clone());
-    let target = Some(Protocol::Service("provide".into()).into());
+    let target = Some(Protocol::Providers("provide".into()).into());
     let arguments = json!({ "service_id": service_id });
     let uuid = message_id();
     let name = Some(format!("Delegate provide service {}", service_id));

--- a/client/fluence-ipfs/src/lib.rs
+++ b/client/fluence-ipfs/src/lib.rs
@@ -41,6 +41,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 const IPFS_SERVICE_ID: &str = "IPFS.multiaddr";
+#[rustfmt::skip]
 static IPFS_SERVICE: Lazy<Protocol> = Lazy::new(|| Protocol::Service(IPFS_SERVICE_ID.to_string()));
 
 fn register_call(client: PeerId, relay: PeerId, service_id: &str, kp: &Keypair) -> FunctionCall {

--- a/client/rust-libp2p/src/client.rs
+++ b/client/rust-libp2p/src/client.rs
@@ -201,9 +201,8 @@ impl Client {
     }
 
     fn send_to_node<R: FunctionCallApi, S: DerefMut<Target = R>>(swarm: &mut S, cmd: Command) {
-        match cmd {
-            Command { node, call } => swarm.call(node, call),
-        }
+        let Command { node, call } = cmd;
+        swarm.call(node, call)
     }
 
     fn receive_from_node(

--- a/client/rust-libp2p/src/main.rs
+++ b/client/rust-libp2p/src/main.rs
@@ -29,7 +29,7 @@
 use async_std::task;
 use clap::{App, Arg};
 use ctrlc_adapter::block_until_ctrlc;
-use faas_api::{service, Address, FunctionCall};
+use faas_api::{provider, Address, FunctionCall};
 use fluence_client::{Client, ClientCommand, ClientEvent};
 use futures::task::Poll;
 use futures::{
@@ -186,7 +186,7 @@ fn print_example(reply_to: Address) {
     let call_identify = ClientCommand::Call {
         call: FunctionCall {
             uuid: uuid(),
-            target: Some(service!("identify")),
+            target: Some(provider!("identify")),
             reply_to: Some(reply_to.clone()),
             arguments: json!({ "hash": "QmFile", "msg_id": time }),
             name: Some("call identify".to_string()),
@@ -197,7 +197,7 @@ fn print_example(reply_to: Address) {
     let register_ipfs_get = ClientCommand::Call {
         call: FunctionCall {
             uuid: uuid(),
-            target: Some(service!("provide")),
+            target: Some(provider!("provide")),
             reply_to: Some(reply_to.clone()),
             arguments: json!({ "service_id": "IPFS.get_QmFile3", "msg_id": time }),
             name: Some("register service".to_string()),
@@ -208,7 +208,7 @@ fn print_example(reply_to: Address) {
     let call_ipfs_get = ClientCommand::Call {
         call: FunctionCall {
             uuid: uuid(),
-            target: Some(service!("IPFS.get_QmFile3")),
+            target: Some(provider!("IPFS.get_QmFile3")),
             reply_to: Some(reply_to.clone()),
             arguments: serde_json::Value::Null,
             name: Some("call ipfs get".to_string()),

--- a/client/rust-libp2p/src/main.rs
+++ b/client/rust-libp2p/src/main.rs
@@ -152,10 +152,10 @@ fn read_cmds_from_stdin() -> UnboundedReceiver<serde_json::error::Result<ClientC
                         cmd_sender.unbounded_send(cmd).expect("send cmd");
                         // Call waker to respawn this future
                         cx.waker().clone().wake();
-                        return Poll::Pending;
+                        Poll::Pending
                     } else {
                         // Return Ready so await below completes
-                        return Poll::Ready(());
+                        Poll::Ready(())
                     }
                 })
                 .await;
@@ -212,7 +212,7 @@ fn print_example(reply_to: Address) {
             reply_to: Some(reply_to.clone()),
             arguments: serde_json::Value::Null,
             name: Some("call ipfs get".to_string()),
-            sender: reply_to.clone(),
+            sender: reply_to,
         },
     };
 

--- a/client/rust-libp2p/tests/endurance.rs
+++ b/client/rust-libp2p/tests/endurance.rs
@@ -15,7 +15,7 @@
  */
 
 use config::{Config, File};
-use faas_api::{service, Address, FunctionCall, Protocol};
+use faas_api::{provider, Address, FunctionCall, Protocol};
 use fluence_client::{Client, ClientEvent};
 use fluence_libp2p::peerid_serializer;
 use libp2p::PeerId;
@@ -234,7 +234,7 @@ async fn wait_call(client: &mut Client, expected_service: &Service) -> Waiting<F
                 let protocols = call.target.as_ref().map(|addr| addr.protocols());
                 debug_assert!(matches!(
                     &protocols.as_deref(),
-                    Some([Protocol::Service(service_id)]) if service_id == &expected_service.id
+                    Some([Protocol::Providers(service_id)]) if service_id == &expected_service.id
                 ));
                 break Waiting::Ok(call);
             }
@@ -252,7 +252,7 @@ fn uuid() -> String {
 fn service_call(sender: Address, service_id: String) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(service!(service_id)),
+        target: Some(provider!(service_id)),
         reply_to: Some(sender.clone()),
         arguments: serde_json::Value::Null,
         name: Some("call service".into()),
@@ -265,7 +265,7 @@ fn registration(sender: Address, service_id: String) -> FunctionCall {
 
     FunctionCall {
         uuid: uuid(),
-        target: Some(service!("provide")),
+        target: Some(provider!("provide")),
         reply_to: Some(sender.clone()),
         arguments: json!({ "service_id": service_id }),
         name: Some("registration".into()),

--- a/faas-api/src/address.rs
+++ b/faas-api/src/address.rs
@@ -336,13 +336,13 @@ macro_rules! relay {
     }};
 }
 
-// Builds service address which looks like this: "/service/ServiceId"
+// Builds service address which looks like this: "/providers/Key"
 #[macro_export]
-macro_rules! service {
+macro_rules! provider {
     ($service_id:expr) => {{
         let id = $service_id;
         // TODO: Will usually clone here, is it ok?
-        $crate::Address::from($crate::Protocol::Service(id.into()))
+        $crate::Address::from($crate::Protocol::Providers(id.into()))
     }};
 }
 
@@ -394,7 +394,7 @@ pub mod tests {
 
         let expected: Address = "fluence:/peer/Qmay8oMmnDmfLpmZtNwisEcmReVVqzvm2vcTc9rPzxeS3x/client/QmWsPEib1mbGSxdqtDGnrqXiZFfVEbvicKS6cf5JfTtaZU/service/IPFS.get_QmFile".parse().unwrap();
 
-        if let Some(Protocol::Service(id)) = iter.peek() {
+        if let Some(Protocol::Providers(id)) = iter.peek() {
             let resolved = imitate_resolve(id).extend(&service);
             assert_eq!(expected, resolved);
 

--- a/faas-api/src/address_protocol.rs
+++ b/faas-api/src/address_protocol.rs
@@ -22,13 +22,15 @@ type Result<T> = core::result::Result<T, AddressError>;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Protocol {
-    // Service on the network
-    Service(String),
+    // Providers of the key
+    Providers(String),
     // Directly accessible peer
     Peer(PeerId),
     // Peer that's accessible only via relay mechanics
     Client(PeerId),
+    // Relay signature
     Signature(Vec<u8>),
+    // Immutable part that comes after '#' in URI
     Hashtag(String),
 }
 
@@ -41,9 +43,9 @@ impl Protocol {
     {
         use self::Protocol::*;
         match iter.next().ok_or(AddressError::Empty)? {
-            "service" => {
+            "providers" => {
                 let id = iter.next().ok_or(AddressError::Empty)?;
-                Ok(Service(id.into()))
+                Ok(Providers(id.into()))
             }
             "peer" => {
                 let id = Self::parse_peer_id(iter)?;
@@ -71,7 +73,7 @@ impl Protocol {
     pub fn components(&self) -> (&'static str, Cow<'_, String>) {
         use self::Protocol::*;
         match self {
-            Service(id) => ("service", Cow::Borrowed(id)),
+            Providers(id) => ("providers", Cow::Borrowed(id)),
             Peer(id) => ("peer", Cow::Owned(Self::peer_id_to_base58(id))),
             Client(id) => ("client", Cow::Owned(Self::peer_id_to_base58(id))),
             // TODO: '/signature' => '?signature='

--- a/faas-api/src/call.rs
+++ b/faas-api/src/call.rs
@@ -125,33 +125,13 @@ pub mod test {
 
     #[test]
     fn serialize_provide() {
-        let provide = provider!("provide") / provider!("IPFS.get_QmFile");
-        let mut call = gen_provide_call(provide, serde_json::Value::Null);
-        call.name = Some("Announce IPFS file (in address)".into());
-
-        check_call(call.clone());
-
-        assert_eq!(
-            call.target,
-            Some("/service/provide/service/IPFS.get_QmFile".parse().unwrap())
-        );
-
         let provide = provider!("provide");
         let arguments = json!({ "service_id": "IPFS.get_QmFile" });
         let mut call = gen_provide_call(provide, arguments);
         call.name = Some("Announce IPFS file (in args)".into());
         check_call(call.clone());
 
-        assert_eq!(call.target, Some("/service/provide".parse().unwrap()));
-
-        let provide = provider!("provide");
-        let mut call = gen_provide_call(provide, serde_json::Value::Null);
-        let notebook = call.reply_to.take().unwrap();
-        call.reply_to = Some(notebook / provider!("IPFS.get_QmFile"));
-        call.name = Some("Announce IPFS file (in reply)".into());
-        check_call(call.clone());
-
-        assert_eq!(call.target, Some("/service/provide".parse().unwrap()));
+        assert_eq!(call.target, Some("/providers/provide".parse().unwrap()));
     }
 
     #[test]

--- a/faas-api/src/call.rs
+++ b/faas-api/src/call.rs
@@ -40,12 +40,12 @@ impl FunctionCall {
 
 pub mod call_test_utils {
     use crate::FunctionCall;
-    use crate::{service, Address};
+    use crate::{provider, Address};
 
     pub fn gen_ipfs_call() -> FunctionCall {
         let sender = Address::random_relay();
         let reply_to = Some(sender.clone());
-        let target = Some(service!("IPFS.get_QmFile"));
+        let target = Some(provider!("IPFS.get_QmFile"));
 
         FunctionCall {
             uuid: "UUID-1".to_string(),
@@ -86,7 +86,7 @@ pub mod test {
     use crate::Address;
     use crate::FunctionCall;
     use crate::Protocol;
-    use crate::{relay, service};
+    use crate::{provider, relay};
     use fluence_libp2p::RandomPeerId;
     use serde_json::json;
 
@@ -103,7 +103,7 @@ pub mod test {
         }
 
         check(relay!(p1.clone(), p2));
-        check(service!("IPFS.get"));
+        check(provider!("IPFS.get"));
         check(Protocol::Peer(p1).into());
     }
 
@@ -125,7 +125,7 @@ pub mod test {
 
     #[test]
     fn serialize_provide() {
-        let provide = service!("provide") / service!("IPFS.get_QmFile");
+        let provide = provider!("provide") / provider!("IPFS.get_QmFile");
         let mut call = gen_provide_call(provide, serde_json::Value::Null);
         call.name = Some("Announce IPFS file (in address)".into());
 
@@ -136,7 +136,7 @@ pub mod test {
             Some("/service/provide/service/IPFS.get_QmFile".parse().unwrap())
         );
 
-        let provide = service!("provide");
+        let provide = provider!("provide");
         let arguments = json!({ "service_id": "IPFS.get_QmFile" });
         let mut call = gen_provide_call(provide, arguments);
         call.name = Some("Announce IPFS file (in args)".into());
@@ -144,10 +144,10 @@ pub mod test {
 
         assert_eq!(call.target, Some("/service/provide".parse().unwrap()));
 
-        let provide = service!("provide");
+        let provide = provider!("provide");
         let mut call = gen_provide_call(provide, serde_json::Value::Null);
         let notebook = call.reply_to.take().unwrap();
-        call.reply_to = Some(notebook / service!("IPFS.get_QmFile"));
+        call.reply_to = Some(notebook / provider!("IPFS.get_QmFile"));
         call.name = Some("Announce IPFS file (in reply)".into());
         check_call(call.clone());
 
@@ -161,8 +161,8 @@ pub mod test {
         let slack_service = "hash(Slack.receiveWebhook_0xdxSECRET_CODE)";
         let github_service = "Github.subscribeNewCommitsToWebhook";
 
-        let slack_service = Some(service!(slack_service));
-        let github_service = Some(service!(github_service));
+        let slack_service = Some(provider!(slack_service));
+        let github_service = Some(provider!(github_service));
         let arguments = json!({"repo": "fluencelabs/fluence", "branch": "all"});
 
         // Notebook sends a call to github, and now github will send new events to slack

--- a/server/src/bootstrapper/behaviour.rs
+++ b/server/src/bootstrapper/behaviour.rs
@@ -77,7 +77,7 @@ impl Bootstrapper {
         let delay = self
             .bootstrap_backoff
             .entry(multiaddr.clone())
-            .or_insert(Backoff::default())
+            .or_insert_with(Backoff::default)
             .next_delay();
 
         self.push_event(
@@ -116,10 +116,9 @@ impl Bootstrapper {
     fn complete_delayed(&mut self, now: Instant) {
         let delayed = mem::replace(&mut self.delayed_events, vec![]);
 
-        let (ready, not_ready) = delayed.into_iter().partition(|(deadline, _)| {
-            let ready = deadline.map(|d| d >= now).unwrap_or(true);
-            ready
-        });
+        let (ready, not_ready) = delayed
+            .into_iter()
+            .partition(|(deadline, _)| deadline.map(|d| d >= now).unwrap_or(true));
 
         self.delayed_events = not_ready;
         self.events = ready.into_iter().map(|(_, e)| e).collect();

--- a/server/src/function/builtin_service.rs
+++ b/server/src/function/builtin_service.rs
@@ -93,6 +93,9 @@ impl BuiltinService {
         [Self::PROVIDE, Self::CERTS, Self::ADD_CERTS, Self::IDENTIFY];
 
     pub fn from<'a>(target: &'a Protocol, arguments: serde_json::Value) -> Result<Self, Error<'a>> {
+        use serde_json::from_value;
+        use BuiltinService::*;
+
         // Check it's `/service/ID` and `ID` is one of builtin services
         let service_id = match target {
             Service(service_id) => service_id,
@@ -100,10 +103,10 @@ impl BuiltinService {
         };
 
         let service = match service_id.as_str() {
-            Self::PROVIDE => BuiltinService::DelegateProviding(serde_json::from_value(arguments)?),
-            Self::CERTS => BuiltinService::GetCertificates(serde_json::from_value(arguments)?),
-            Self::ADD_CERTS => BuiltinService::AddCertificates(serde_json::from_value(arguments)?),
-            Self::IDENTIFY => BuiltinService::Identify(serde_json::from_value(arguments)?),
+            Self::PROVIDE => DelegateProviding(from_value(arguments)?),
+            Self::CERTS => GetCertificates(from_value(arguments)?),
+            Self::ADD_CERTS => AddCertificates(from_value(arguments)?),
+            Self::IDENTIFY => Identify(from_value(arguments)?),
             s => return Err(Error::UnknownService(s)),
         };
 

--- a/server/src/function/builtin_service.rs
+++ b/server/src/function/builtin_service.rs
@@ -98,7 +98,7 @@ impl BuiltinService {
 
         // Check it's `/service/ID` and `ID` is one of builtin services
         let service_id = match target {
-            Service(service_id) => service_id,
+            Providers(service_id) => service_id,
             _ => return Err(Error::InvalidProtocol(target)),
         };
 
@@ -115,7 +115,7 @@ impl BuiltinService {
 
     pub fn is_builtin(service: &Protocol) -> bool {
         match service {
-            Service(service_id) => Self::SERVICES.contains(&service_id.as_str()),
+            Providers(service_id) => Self::SERVICES.contains(&service_id.as_str()),
             _ => false,
         }
     }
@@ -131,7 +131,7 @@ impl Into<(Protocol, serde_json::Value)> for BuiltinService {
             BuiltinService::AddCertificates { .. } => BuiltinService::ADD_CERTS,
             BuiltinService::Identify { .. } => BuiltinService::IDENTIFY,
         };
-        let target = Protocol::Service(service_id.to_string());
+        let target = Protocol::Providers(service_id.to_string());
         let arguments = json!(self);
 
         (target, arguments)
@@ -159,7 +159,7 @@ pub mod test {
         let protocols = call.target.as_ref().expect("non empty").protocols();
 
         let service_id = match protocols.as_slice() {
-            [Protocol::Service(service_id)] => service_id,
+            [Protocol::Providers(service_id)] => service_id,
             wrong => unreachable!("target should be Address::Service, was {:?}", wrong),
         };
 

--- a/server/src/function/execution.rs
+++ b/server/src/function/execution.rs
@@ -21,7 +21,7 @@ use super::{
     },
     FunctionRouter,
 };
-use faas_api::{provider, Address, FunctionCall, Protocol};
+use faas_api::{hashtag, Address, FunctionCall, Protocol};
 use itertools::Itertools;
 use libp2p::PeerId;
 use serde_json::json;
@@ -41,7 +41,7 @@ impl FunctionRouter {
 
         match service {
             BS::DelegateProviding(DelegateProviding { service_id }) => {
-                self.provide(provider!(service_id), call)
+                self.provide(hashtag!(service_id), call)
             }
             BS::GetCertificates(GetCertificates { peer_id, msg_id }) => {
                 self.get_certificates(peer_id, call, msg_id, ttl)

--- a/server/src/function/execution.rs
+++ b/server/src/function/execution.rs
@@ -21,15 +21,15 @@ use super::{
     },
     FunctionRouter,
 };
-use faas_api::{service, Address, FunctionCall, Protocol};
+use faas_api::{provider, Address, FunctionCall, Protocol};
 use itertools::Itertools;
 use libp2p::PeerId;
 use serde_json::json;
 use trust_graph::Certificate;
 
 impl FunctionRouter {
-    /// Execute call on builtin service: "provide" or "certificates"
-    /// `ttl` – time to live, if `0`, "certificates" and "add_certificates" services
+    /// Execute call on builtin service: "provide", "certificates", etc
+    /// `ttl` – time to live, if `0`, then "certificates" and "add_certificates" services
     ///  won't send call to neighborhood
     pub(super) fn execute_builtin(
         &mut self,
@@ -41,7 +41,7 @@ impl FunctionRouter {
 
         match service {
             BS::DelegateProviding(DelegateProviding { service_id }) => {
-                self.provide(service!(service_id), call)
+                self.provide(provider!(service_id), call)
             }
             BS::GetCertificates(GetCertificates { peer_id, msg_id }) => {
                 self.get_certificates(peer_id, call, msg_id, ttl)

--- a/server/src/function/peers.rs
+++ b/server/src/function/peers.rs
@@ -193,7 +193,7 @@ impl FunctionRouter {
     }
 
     pub(super) fn search_for_client(&mut self, client: PeerId, call: FunctionCall) {
-        self.find_service_provider(Protocol::Client(client).into(), call)
+        self.find_providers(Protocol::Client(client).into(), call)
     }
 
     pub(super) fn peer_status(&mut self, peer: &PeerId) -> PeerStatus {

--- a/server/src/function/router.rs
+++ b/server/src/function/router.rs
@@ -147,16 +147,16 @@ impl FunctionRouter {
                     self.send_to(id.clone(), Unknown, call.with_target(target.collect()), ctx);
                     return;
                 }
-                s @ Service(_) if is_local || self.service_available_locally(s) => {
+                s @ Providers(_) if is_local || self.service_available_locally(s) => {
                     // If targeted to local, terminate locally, don't forward to network
                     let ttl = if is_local { 0 } else { 1 };
                     // target will be like: /client/QmClient/service/QmService
                     self.pass_to_local_service(s.clone(), call.with_target(target.collect()), ttl);
                     return;
                 }
-                s @ Service(_) => {
-                    log::info!("{} not found locally. uuid {}", &s, &call.uuid);
-                    self.find_service_provider(s.into(), call.with_target(target.collect()));
+                s @ Providers(_) => {
+                    log::info!("searching for providers of {}. uuid {}", &s, &call.uuid);
+                    self.find_providers(s.into(), call.with_target(target.collect()));
                     return;
                 }
                 Client(id) if is_local => {

--- a/server/src/function/router_behaviour.rs
+++ b/server/src/function/router_behaviour.rs
@@ -188,8 +188,8 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<KademliaEvent> for FunctionRout
 
         log::debug!("Kademlia inject: {:?}", event);
 
-        match event {
-            QueryResult { result, .. } => match result {
+        if let QueryResult { result, .. } = event {
+            match result {
                 GetClosestPeers(result) => {
                     let (key, peers) = match result {
                         Ok(GetClosestPeersOk { key, peers }) => (key, peers),
@@ -200,8 +200,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<KademliaEvent> for FunctionRout
                 GetRecord(result) => self.name_resolved(result),
                 PutRecord(Err(result)) => self.name_publish_failed(result),
                 _ => {}
-            },
-            _ => {}
+            }
         };
     }
 }

--- a/server/src/function/services.rs
+++ b/server/src/function/services.rs
@@ -18,7 +18,7 @@ use super::builtin_service::BuiltinService;
 //use super::router::Service::Delegated;
 use super::FunctionRouter;
 use crate::function::waiting_queues::Enqueued;
-use faas_api::{Address, FunctionCall, Protocol};
+use faas_api::{provider, Address, FunctionCall, Protocol};
 use libp2p::PeerId;
 use std::collections::HashSet;
 
@@ -27,20 +27,20 @@ impl FunctionRouter {
     // ## Service routing
     // ###
 
-    pub(super) fn service_available_locally(&self, service: &Protocol) -> bool {
-        BuiltinService::is_builtin(service) || self.provided_names.contains_key(&service.into())
+    pub(super) fn service_available_locally(&self, service: &str) -> bool {
+        BuiltinService::is_builtin(service) || self.provided_names.contains_key(&provider!(service))
     }
 
     /// Execute call locally: on builtin service or forward to provided name
     /// `ttl` – time to live (akin to ICMP ttl), if `0`, execute and drop, don't forward  
     pub(super) fn pass_to_local_service(
         &mut self,
-        service: Protocol,
+        service: &str,
         mut call: FunctionCall,
         ttl: usize,
     ) {
-        if BuiltinService::is_builtin(&service) {
-            match BuiltinService::from(&service, call.arguments.clone()) {
+        if BuiltinService::is_builtin(service) {
+            match BuiltinService::from(service, call.arguments.clone()) {
                 Ok(builtin) => self.execute_builtin(builtin, call, ttl),
                 Err(err) => {
                     self.send_error_on_call(call, format!("builtin service error: {}", err))
@@ -49,7 +49,7 @@ impl FunctionRouter {
             return;
         }
 
-        if let Some(provider) = self.provided_names.get(&Address::from(&service)).cloned() {
+        if let Some(provider) = self.provided_names.get(&provider!(service)).cloned() {
             log::info!(
                 "Service {} was found locally. uuid {}",
                 &service,

--- a/server/src/function/services.rs
+++ b/server/src/function/services.rs
@@ -70,7 +70,7 @@ impl FunctionRouter {
     }
 
     // Look for service providers, enqueue call to wait for providers
-    pub(super) fn find_service_provider(&mut self, name: Address, call: FunctionCall) {
+    pub(super) fn find_providers(&mut self, name: Address, call: FunctionCall) {
         log::info!("Finding service provider for {}, call: {:?}", name, call);
         if let Enqueued::New = self.wait_name_resolved.enqueue(name.clone(), call) {
             // won't call get_providers if there are already calls waiting for it

--- a/server/tests/routing.rs
+++ b/server/tests/routing.rs
@@ -27,7 +27,7 @@
     unreachable_patterns
 )]
 
-use faas_api::{service, FunctionCall, Protocol};
+use faas_api::{provider, FunctionCall, Protocol};
 use fluence_client::Transport;
 use libp2p::{identity::PublicKey::Ed25519, PeerId};
 use parity_multiaddr::Multiaddr;
@@ -148,7 +148,7 @@ fn call_service() {
     );
     assert_eq!(
         to_provider.target,
-        Some(provider.client_address().extend(service!(service_id)))
+        Some(provider.client_address().extend(provider!(service_id)))
     );
 }
 
@@ -229,7 +229,7 @@ fn provide_disconnect() {
     );
     assert_eq!(
         to_provider.target,
-        Some(provider.client_address().extend(service!(service_id)))
+        Some(provider.client_address().extend(provider!(service_id)))
     );
 }
 
@@ -414,7 +414,7 @@ fn identify() {
     check_reply(&mut consumer, &swarms[1].1, &msg_id);
 
     for swarm in swarms {
-        identify_call.target = Some(Peer(swarm.0.clone()) / service!("identify"));
+        identify_call.target = Some(Peer(swarm.0.clone()) / provider!("identify"));
         consumer.send(identify_call.clone());
         check_reply(&mut consumer, &swarm.1, &msg_id);
     }

--- a/server/tests/routing.rs
+++ b/server/tests/routing.rs
@@ -27,7 +27,7 @@
     unreachable_patterns
 )]
 
-use faas_api::{provider, FunctionCall, Protocol};
+use faas_api::{hashtag, provider, FunctionCall, Protocol};
 use fluence_client::Transport;
 use libp2p::{identity::PublicKey::Ed25519, PeerId};
 use parity_multiaddr::Multiaddr;
@@ -136,7 +136,7 @@ fn call_service() {
     let provide = provide_call(service_id, provider.relay_address());
     provider.send(provide);
 
-    let call_service = service_call(service_id, consumer.relay_address());
+    let call_service = service_call(provider!(service_id), consumer.relay_address());
     consumer.send(call_service.clone());
 
     let to_provider = provider.receive();
@@ -163,7 +163,7 @@ fn call_service_reply() {
     let provide = provide_call(service_id, provider.relay_address());
     provider.send(provide);
 
-    let call_service = service_call(service_id, consumer.relay_address());
+    let call_service = service_call(provider!(service_id), consumer.relay_address());
     consumer.send(call_service);
 
     let to_provider = provider.receive();
@@ -202,7 +202,7 @@ fn provide_disconnect() {
     provider.client.stop();
 
     // Send call to the service, should fail
-    let mut call_service = service_call(service_id, consumer.relay_address());
+    let mut call_service = service_call(provider!(service_id), consumer.relay_address());
     call_service.name = Some("Send call to the service, should fail".into());
     consumer.send(call_service.clone());
     let error = consumer.receive();
@@ -268,7 +268,7 @@ fn reconnect_provide() {
 
     sleep(KAD_TIMEOUT);
 
-    let call_service = service_call(service_id, consumer.relay_address());
+    let call_service = service_call(provider!(service_id), consumer.relay_address());
     consumer.send(call_service.clone());
 
     let to_provider = provider.receive();
@@ -399,15 +399,16 @@ fn identify() {
 
     let mut consumer = ConnectedClient::connect_to(swarms[1].1.clone()).expect("connect consumer");
 
-    let mut identify_call = service_call("identify", consumer.relay_address());
+    let mut identify_call = service_call(hashtag!("identify"), consumer.relay_address());
     let msg_id = uuid();
     identify_call.arguments = json!({ "msg_id": msg_id });
     consumer.send(identify_call.clone());
 
     fn check_reply(consumer: &mut ConnectedClient, swarm_addr: &Multiaddr, msg_id: &str) {
         let reply = consumer.receive();
+        println!("reply: {:#?}", reply);
         #[rustfmt::skip]
-            let reply_msg_id = reply.arguments.get("msg_id").expect("not empty").as_str().expect("str");
+        let reply_msg_id = reply.arguments.get("msg_id").expect("not empty").as_str().expect("str");
         assert_eq!(reply_msg_id, msg_id);
         let addrs = reply.arguments["addresses"].as_array().expect("not empty");
         assert!(!addrs.is_empty());
@@ -418,7 +419,7 @@ fn identify() {
     check_reply(&mut consumer, &swarms[1].1, &msg_id);
 
     for swarm in swarms {
-        identify_call.target = Some(Peer(swarm.0.clone()) / provider!("identify"));
+        identify_call.target = Some(Peer(swarm.0.clone()) / hashtag!("identify"));
         consumer.send(identify_call.clone());
         check_reply(&mut consumer, &swarm.1, &msg_id);
     }

--- a/server/tests/routing.rs
+++ b/server/tests/routing.rs
@@ -344,7 +344,11 @@ fn add_certs() {
     // If count is small, all nodes should fit in neighborhood, and all of them should reply
     for _ in 0..swarm_count {
         let reply = registrar.receive();
-        assert_eq!(reply.arguments["msg_id"], call.arguments["msg_id"]);
+        assert_eq!(
+            reply.arguments["msg_id"], call.arguments["msg_id"],
+            "{:#?}",
+            reply
+        );
     }
 }
 

--- a/server/tests/run_multiple_nodes.rs
+++ b/server/tests/run_multiple_nodes.rs
@@ -17,6 +17,7 @@
 #![allow(unused_imports, dead_code)]
 
 use async_std::task;
+use faas_api::provider;
 use fluence_client::Transport;
 use fluence_server::Server;
 use libp2p::core::multiaddr::{Multiaddr, Protocol};
@@ -152,7 +153,9 @@ fn receive_call_on_big_network() {
         client20.send(provide_call(service_id, client20.relay_address()));
         sleep(KAD_TIMEOUT);
 
-        client30.send(service_call(service_id, client30.relay_address()));
+        let service_id = provider!(service_id);
+
+        client30.send(service_call(service_id.clone(), client30.relay_address()));
         let call30to20 = client20.receive();
         log::info!("call30to20: {:?}", call30to20);
 

--- a/server/tests/run_multiple_nodes.rs
+++ b/server/tests/run_multiple_nodes.rs
@@ -114,7 +114,7 @@ fn receive_call_on_big_network() {
     use rand::distributions::Alphanumeric;
 
     let localhost = "127.0.0.1".parse().unwrap();
-    let count = 15;
+    let count = 10;
     start_bunch(count, 20000, localhost, None, count, None);
     start_bunch(count, 30000, localhost, Some(20000), count, None);
     start_bunch(count, 40000, localhost, Some(30000), count, None);

--- a/server/tests/utils/misc.rs
+++ b/server/tests/utils/misc.rs
@@ -83,10 +83,10 @@ pub fn provide_call(service_id: &str, sender: Address) -> FunctionCall {
     }
 }
 
-pub fn service_call(service_id: &str, sender: Address) -> FunctionCall {
+pub fn service_call(service: Address, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(hashtag!(service_id)),
+        target: Some(service),
         reply_to: Some(sender.clone()),
         arguments: Value::Null,
         name: None,

--- a/server/tests/utils/misc.rs
+++ b/server/tests/utils/misc.rs
@@ -15,7 +15,7 @@
  */
 
 use async_std::task;
-use faas_api::{service, Address, FunctionCall};
+use faas_api::{provider, Address, FunctionCall};
 use fluence_libp2p::{build_memory_transport, build_transport};
 use fluence_server::ServerBehaviour;
 
@@ -44,7 +44,7 @@ pub static KAD_TIMEOUT: Duration = Duration::from_millis(500);
 pub fn certificates_call(peer_id: PeerId, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(service!("certificates")),
+        target: Some(provider!("certificates")),
         reply_to: Some(sender.clone()),
         arguments: json!({ "peer_id": peer_id.to_string(), "msg_id": uuid() }),
         name: None,
@@ -60,7 +60,7 @@ pub fn add_certificates_call(
     let certs: Vec<_> = certs.into_iter().map(|c| c.to_string()).collect();
     FunctionCall {
         uuid: uuid(),
-        target: Some(service!("add_certificates")),
+        target: Some(provider!("add_certificates")),
         reply_to: Some(sender.clone()),
         arguments: json!({
             "peer_id": peer_id.to_string(),
@@ -75,7 +75,7 @@ pub fn add_certificates_call(
 pub fn provide_call(service_id: &str, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(service!("provide")),
+        target: Some(provider!("provide")),
         reply_to: Some(sender.clone()),
         arguments: json!({ "service_id": service_id }),
         name: None,
@@ -86,7 +86,7 @@ pub fn provide_call(service_id: &str, sender: Address) -> FunctionCall {
 pub fn service_call(service_id: &str, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(service!(service_id)),
+        target: Some(provider!(service_id)),
         reply_to: Some(sender.clone()),
         arguments: Value::Null,
         name: None,

--- a/server/tests/utils/misc.rs
+++ b/server/tests/utils/misc.rs
@@ -15,7 +15,7 @@
  */
 
 use async_std::task;
-use faas_api::{provider, Address, FunctionCall};
+use faas_api::{hashtag, Address, FunctionCall};
 use fluence_libp2p::{build_memory_transport, build_transport};
 use fluence_server::ServerBehaviour;
 
@@ -44,7 +44,7 @@ pub static KAD_TIMEOUT: Duration = Duration::from_millis(500);
 pub fn certificates_call(peer_id: PeerId, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(provider!("certificates")),
+        target: Some(hashtag!("certificates")),
         reply_to: Some(sender.clone()),
         arguments: json!({ "peer_id": peer_id.to_string(), "msg_id": uuid() }),
         name: None,
@@ -60,7 +60,7 @@ pub fn add_certificates_call(
     let certs: Vec<_> = certs.into_iter().map(|c| c.to_string()).collect();
     FunctionCall {
         uuid: uuid(),
-        target: Some(provider!("add_certificates")),
+        target: Some(hashtag!("add_certificates")),
         reply_to: Some(sender.clone()),
         arguments: json!({
             "peer_id": peer_id.to_string(),
@@ -75,7 +75,7 @@ pub fn add_certificates_call(
 pub fn provide_call(service_id: &str, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(provider!("provide")),
+        target: Some(hashtag!("provide")),
         reply_to: Some(sender.clone()),
         arguments: json!({ "service_id": service_id }),
         name: None,
@@ -86,7 +86,7 @@ pub fn provide_call(service_id: &str, sender: Address) -> FunctionCall {
 pub fn service_call(service_id: &str, sender: Address) -> FunctionCall {
     FunctionCall {
         uuid: uuid(),
-        target: Some(provider!(service_id)),
+        target: Some(hashtag!(service_id)),
         reply_to: Some(sender.clone()),
         arguments: Value::Null,
         name: None,


### PR DESCRIPTION
1. Local services are now addressed via `#`: `fluence:/peer/QmPeer#identify`
2. `/service` renamed to `/providers`: `fluence:/service/IPFS`
3. Services are now published to DHT by `#`. This means that calling 
```
FunctionCall {
  target: fluence:/#provide
  arguments: { service_id: IPFS },
  reply_to: /peer/QmPeer/client/QmClient/signature/QmSig,
  ...
}
```
Will publish to DHT the following: `#IPFS -> [ /peer/QmPee/client/QmClient/signature/QmSig ]`

4. Same conversion happens when resolving providers through DHT. A request like
```
FunctionCall {
  target: fluence:/providers/IPFS,
  ...
}
```
Will result in searching for `#IPFS` on DHT, and then forwarding call, using `#IPFS`:
```
target: fluence:/peer/QmPeer/client/QmClient#IPFS
```
