### PR TITLE
Isolate mapped_dirs and preopened_files among faas instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 [[package]]
 name = "fce"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
+source = "git+https://github.com/fluencelabs/fce?branch=master#ea7219f477765a2cacc0282acbdede7e8a916929"
 dependencies = [
  "fce-wit-interfaces",
  "log",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "fce-wit-interfaces"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
+source = "git+https://github.com/fluencelabs/fce?branch=master#ea7219f477765a2cacc0282acbdede7e8a916929"
 dependencies = [
  "multimap",
  "wasmer-interface-types",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "fluence-faas"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
+source = "git+https://github.com/fluencelabs/fce?branch=master#ea7219f477765a2cacc0282acbdede7e8a916929"
 dependencies = [
  "cmd_lib",
  "fce",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
+source = "git+https://github.com/fluencelabs/fce?branch=master#ea7219f477765a2cacc0282acbdede7e8a916929"
 dependencies = [
  "anyhow",
  "fce-wit-interfaces",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arc-swap"
@@ -246,9 +246,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-timer"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090be1cde9a4243a6c1237cd18fb540d66419e0a01c9e71fe1183604662b61af"
+checksum = "ba5fa6ed76cb2aa820707b4eb9ec46f42da9ce70b0eafab5e5e34942b38a44d5"
 dependencies = [
  "futures-core",
  "libc",
@@ -593,9 +593,9 @@ checksum = "475bd7aa7680b4ed8f6bb59745e882bcbaeb39326532bb79ffb1716480d9a274"
 
 [[package]]
 name = "concurrent-queue"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
+checksum = "1582139bb74d97ef232c30bc236646017db06f13ee7cc01fa24c9e55640f86d4"
 dependencies = [
  "cache-padded",
 ]
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699d84875f1b72b4da017e6b0f77dfa88c0137f089958a88974d15938cbc2976"
+checksum = "829694371bd7bbc6aee17c4ff624aad8bf9f4dc06c6f9f6071eaa08c89530d10"
 
 [[package]]
 name = "faas-api"
@@ -1088,7 +1088,7 @@ checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 [[package]]
 name = "fce"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=master#fa3ae391ecc99f14acee57862adc799f88dd3dc9"
+source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
 dependencies = [
  "fce-wit-interfaces",
  "log",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "fce-wit-interfaces"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=master#fa3ae391ecc99f14acee57862adc799f88dd3dc9"
+source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
 dependencies = [
  "multimap",
  "wasmer-interface-types",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "fluence-faas"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=master#fa3ae391ecc99f14acee57862adc799f88dd3dc9"
+source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
 dependencies = [
  "cmd_lib",
  "fce",
@@ -1335,15 +1335,17 @@ checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0bbcb0ec905ef6ee23fab499119b5da2362b8697d66e08d1ef01a8c0d438e2"
+checksum = "bbe71459749b2e8e66fb95df721b22fa08661ad384a0c5b519e11d3893b4692a"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
+ "parking",
  "pin-project-lite",
+ "waker-fn",
 ]
 
 [[package]]
@@ -2761,9 +2763,9 @@ checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
 name = "parking"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d4a6da31f8144a32532fe38fe8fb439a6842e0ec633f0037f0144c14e7f907"
+checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
 
 [[package]]
 name = "parking_lot"
@@ -2839,18 +2841,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2902,9 +2904,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
@@ -3220,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
+checksum = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
 dependencies = [
  "base64 0.12.3",
  "bytes",
@@ -3233,6 +3235,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-tls",
+ "ipnet",
  "js-sys",
  "lazy_static",
  "log",
@@ -3329,6 +3332,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safe-transmute"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b8b2cd387f744f69469aaed197954ba4c0ecdb31e02edf99b023e0df11178a"
 
 [[package]]
 name = "salsa20"
@@ -3492,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -3744,9 +3753,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
+checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3873,9 +3882,9 @@ checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
  "bytes",
  "fnv",
@@ -3947,9 +3956,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
+checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
 dependencies = [
  "cfg-if",
  "log",
@@ -4359,10 +4368,12 @@ dependencies = [
 [[package]]
 name = "wasmer-interface-types"
 version = "0.17.0"
-source = "git+http://github.com/fluencelabs/interface-types?branch=byte_array#4521e79a50e39dfa155d07e74ffc7d12203fa198"
+source = "git+http://github.com/fluencelabs/interface-types?branch=struct_support#33ce6228c8ad668bdae6487c6df44c6b09763454"
 dependencies = [
  "nom",
+ "safe-transmute",
  "serde 1.0.114",
+ "serde_json",
  "wast",
 ]
 
@@ -4569,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
-source = "git+https://github.com/fluencelabs/fce?branch=master#fa3ae391ecc99f14acee57862adc799f88dd3dc9"
+source = "git+https://github.com/fluencelabs/fce?branch=interface_serialize#72d262ef73406614b962a17a32d1d583ad96eb44"
 dependencies = [
  "anyhow",
  "fce-wit-interfaces",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ trust-graph = { path = "../trust-graph" }
 fluence-libp2p = { path = "../crates/libp2p" }
 ctrlc-adapter = { path = "../crates/ctrlc-adapter"}
 faas-api = { path = "../faas-api" }
-fluence-faas = { git = "https://github.com/fluencelabs/fce", branch = "interface_serialize" }
+fluence-faas = { git = "https://github.com/fluencelabs/fce", branch = "master" }
 libp2p = { git = "https://github.com/fluencelabs/rust-libp2p", branch = "master" }
 parity-multiaddr = { git = "https://github.com/fluencelabs/rust-libp2p", branch = "master" }
 multihash ="0.11.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ trust-graph = { path = "../trust-graph" }
 fluence-libp2p = { path = "../crates/libp2p" }
 ctrlc-adapter = { path = "../crates/ctrlc-adapter"}
 faas-api = { path = "../faas-api" }
-fluence-faas = { git = "https://github.com/fluencelabs/fce", branch = "master" }
+fluence-faas = { git = "https://github.com/fluencelabs/fce", branch = "interface_serialize" }
 libp2p = { git = "https://github.com/fluencelabs/rust-libp2p", branch = "master" }
 parity-multiaddr = { git = "https://github.com/fluencelabs/rust-libp2p", branch = "master" }
 multihash ="0.11.0"

--- a/server/src/faas/behaviour.rs
+++ b/server/src/faas/behaviour.rs
@@ -156,7 +156,6 @@ impl FaaSBehaviour {
         Ok(faas.get_interface())
     }
 
-    #[allow(dead_code)]
     /// Get interfaces for all created FaaS instances
     pub fn get_interfaces(&self) -> HashMap<&str, FaaSInterface<'_>> {
         self.faases

--- a/server/src/faas/behaviour.rs
+++ b/server/src/faas/behaviour.rs
@@ -199,6 +199,7 @@ impl FaaSBehaviour {
     }
 
     /// Appends path `service_id` to all mapped and preopened directories in the config
+    /// TODO: this is an ad hoc solution, this could be implemented naturally on module loading level.
     fn change_dirs(
         mut config: RawCoreModulesConfig,
         service_id: &str,

--- a/server/src/function/errors.rs
+++ b/server/src/function/errors.rs
@@ -72,10 +72,6 @@ impl CallError {
             CallErrorKind::AddCertificates(failed) => {
                 format!("failed to add certificates: {:?}", failed)
             }
-            CallErrorKind::FaasInterfaceSerialization(err) => format!(
-                "Totally unexpected: can't serialize FaaS interface to json: {}",
-                err
-            ),
             CallErrorKind::MissingServiceId => {
                 "service id must be specified after # in the target address".to_string()
             }
@@ -107,7 +103,6 @@ pub enum CallErrorKind {
     MissingPublicKey,
     UnsupportedPublicKey,
     AddCertificates(Vec<(Certificate, String)>),
-    FaasInterfaceSerialization(serde_json::Error),
     MissingServiceId,
     NoSuchModule { module: String, service_id: String },
     FaaSExecError(FaaSExecError),

--- a/server/src/function/execution.rs
+++ b/server/src/function/execution.rs
@@ -66,7 +66,12 @@ impl FunctionRouter {
                 self.reply_with(call, msg_id, ("interface", json!(interface)))
             }
             BuiltinService::GetActiveInterfaces(GetActiveInterfaces { msg_id }) => {
-                let interfaces = json!(self.faas.get_interfaces());
+                let interfaces: Vec<_> = self
+                    .faas
+                    .get_interfaces()
+                    .into_iter()
+                    .map(|(id, service)| json!({"service_id": id, "service": service}))
+                    .collect();
                 self.reply_with(call, msg_id, ("active_interfaces", interfaces))
             }
             BuiltinService::GetAvailableModules(GetAvailableModules { msg_id }) => {

--- a/server/src/function/execution.rs
+++ b/server/src/function/execution.rs
@@ -61,10 +61,9 @@ impl FunctionRouter {
                     .faas
                     .get_interface(service_id.as_str())
                     .map_err(|e| call.clone().error(e))?;
-                match serde_json::to_value(interface) {
-                    Ok(interface) => self.reply_with(call, msg_id, ("interface", interface)),
-                    Err(err) => Err(call.error(FaasInterfaceSerialization(err))),
-                }
+                let interface = json!(interface);
+
+                self.reply_with(call, msg_id, ("interface", json!(interface)))
             }
             BuiltinService::GetActiveInterfaces(GetActiveInterfaces { msg_id }) => {
                 let interfaces = json!(self.faas.get_interfaces());

--- a/server/src/function/services.rs
+++ b/server/src/function/services.rs
@@ -135,18 +135,10 @@ impl FunctionRouter {
     // Look for service providers, enqueue call to wait for providers
     pub(super) fn find_providers(&mut self, name: Address, call: FunctionCall) {
         log::info!("Finding service provider for {}, call: {:?}", name, call);
-        if let Enqueued::New = self
-            .wait_address
-            .enqueue(name.clone(), WaitAddress::ProviderFound(call))
-        {
-            // won't call get_providers if there are already calls waiting for it
-            self.resolve_name(&name)
-        } else {
-            log::debug!(
-                "won't call resolve_name because there are already promises waiting for {}",
-                name
-            )
-        }
+        self.wait_address
+            .enqueue(name.clone(), WaitAddress::ProviderFound(call));
+        // TODO: don't call resolve_name if there is the same request in progress
+        self.resolve_name(&name)
     }
 
     // Advance execution for calls waiting for this service: send them to first provider

--- a/server/src/function/services.rs
+++ b/server/src/function/services.rs
@@ -18,7 +18,6 @@ use super::builtin_service::BuiltinService;
 use super::FunctionRouter;
 use crate::faas::{FaaSCall, FaaSCallResult, FaaSExecError};
 use crate::function::wait_address::WaitAddress;
-use crate::function::waiting_queues::Enqueued;
 use crate::function::{CallError, CallErrorKind::*, ErrorData};
 use faas_api::{Address, FunctionCall, Protocol};
 use fluence_faas::IValue;

--- a/server/tests/routing.rs
+++ b/server/tests/routing.rs
@@ -487,7 +487,7 @@ fn get_interface() {
     client.send(call);
     let received = client.receive();
 
-    let expected: Interface = serde_json::from_str(r#"{"modules":{"test_one.wasm":{"empty":{"input_types":[],"output_types":[]},"greeting":{"input_types":["String"],"output_types":["String"]}},"test_two.wasm":{"empty":{"input_types":[],"output_types":[]},"greeting":{"input_types":["String"],"output_types":["String"]}}}}"#).unwrap();
+    let expected: Interface = serde_json::from_str(r#"{"modules":[{"name":"test_one.wasm","functions":[{"name":"empty","input_types":[],"output_types":[]},{"name":"greeting","input_types":["String"],"output_types":["String"]}]},{"name":"test_two.wasm","functions":[{"name":"empty","input_types":[],"output_types":[]},{"name":"greeting","input_types":["String"],"output_types":["String"]}]}]}"#).unwrap();
     let actual: Interface =
         serde_json::from_value(received.arguments["interface"].clone()).unwrap();
 
@@ -616,7 +616,7 @@ fn get_interfaces() {
     client.send(call);
     let received = client.receive();
 
-    let expected: Interface = serde_json::from_str(r#"{"modules":{"test_one.wasm":{"empty":{"input_types":[],"output_types":[]},"greeting":{"input_types":["String"],"output_types":["String"]}},"test_two.wasm":{"empty":{"input_types":[],"output_types":[]},"greeting":{"input_types":["String"],"output_types":["String"]}}}}"#).unwrap();
+    let expected: Interface = serde_json::from_str(r#"{"modules":[{"name":"test_one.wasm","functions":[{"name":"empty","input_types":[],"output_types":[]},{"name":"greeting","input_types":["String"],"output_types":["String"]}]},{"name":"test_two.wasm","functions":[{"name":"empty","input_types":[],"output_types":[]},{"name":"greeting","input_types":["String"],"output_types":["String"]}]}]}"#).unwrap();
     let actual: Interface =
         serde_json::from_value(received.arguments["active_interfaces"][service_id1].clone())
             .unwrap();

--- a/server/tests/routing.rs
+++ b/server/tests/routing.rs
@@ -617,15 +617,20 @@ fn get_interfaces() {
     let received = client.receive();
 
     let expected: Interface = serde_json::from_str(r#"{"modules":[{"name":"test_one.wasm","functions":[{"name":"empty","input_types":[],"output_types":[]},{"name":"greeting","input_types":["String"],"output_types":["String"]}]},{"name":"test_two.wasm","functions":[{"name":"empty","input_types":[],"output_types":[]},{"name":"greeting","input_types":["String"],"output_types":["String"]}]}]}"#).unwrap();
-    let actual: Interface =
-        serde_json::from_value(received.arguments["active_interfaces"][service_id1].clone())
-            .unwrap();
+
+    #[rustfmt::skip]
+    let actual: Interface = serde_json::from_value(
+        received.arguments["active_interfaces"].as_array().unwrap().iter().find(|i| i["service_id"] == service_id1).unwrap().clone(),
+    )
+    .unwrap();
 
     assert_eq!(expected, actual);
 
-    let actual: Interface =
-        serde_json::from_value(received.arguments["active_interfaces"][service_id2].clone())
-            .unwrap();
+    #[rustfmt::skip]
+    let actual: Interface = serde_json::from_value(
+        received.arguments["active_interfaces"].as_array().unwrap().iter().find(|i| i["service_id"] == service_id2).unwrap().clone(),
+    )
+    .unwrap();
 
     assert_eq!(expected, actual);
 }


### PR DESCRIPTION
I don't like this solution, it's too fragile. 

Ideally, there should be an abstraction that manages its directories, and interprets `mapped_dirs` as relative paths to service directory. 

But for now, it should do.