### PR TITLE
Add timeouts to connection pool & kademlia

### DIFF
--- a/.github/workflows/rust_audit.yml
+++ b/.github/workflows/rust_audit.yml
@@ -13,4 +13,7 @@ jobs:
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        # do not fail: waiting for cranelift-native to release removal of raw-cpuid dependency
+        # https://github.com/bytecodealliance/wasmtime/pull/2607
+        continue-on-error: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "fluence-fork-libp2p",
  "fluence-libp2p",
  "futures",
+ "itertools 0.10.0",
  "log",
  "parking_lot 0.11.1",
  "particle-protocol",
@@ -2608,6 +2609,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]

--- a/aquamarine/src/vm_pool.rs
+++ b/aquamarine/src/vm_pool.rs
@@ -67,7 +67,6 @@ impl VmPool {
     pub fn poll(&mut self, cx: &mut Context<'_>) {
         let creating_vms = match &mut self.creating_vms {
             None => {
-                log::info!(target: "debug_vms", "Started creating VMs");
                 self.creating_vms = Some(
                     (0..self.config.pool_size)
                         .map(|_| {

--- a/connection-pool/Cargo.toml
+++ b/connection-pool/Cargo.toml
@@ -14,7 +14,8 @@ libp2p = { package = "fluence-fork-libp2p", version = "0.34.0" }
 futures = "0.3.8"
 log = "0.4.13"
 serde = "1.0.118"
+async-std = "1.9.0"
+itertools = "0.10.0"
 
 [dev-dependencies]
-async-std = "1.8.0"
 parking_lot = "0.11.1"

--- a/connection-pool/src/behaviour.rs
+++ b/connection-pool/src/behaviour.rs
@@ -81,6 +81,8 @@ impl Peer {
 }
 
 pub struct ConnectionPoolBehaviour {
+    peer_id: PeerId,
+
     outlet: BackPressuredOutlet<Particle>,
     subscribers: Vec<Outlet<LifecycleEvent>>,
 
@@ -161,10 +163,12 @@ impl ConnectionPoolBehaviour {
     pub fn new(
         buffer: usize,
         protocol_config: ProtocolConfig,
+        peer_id: PeerId,
     ) -> (Self, BackPressuredInlet<Particle>) {
         let (outlet, inlet) = mpsc::channel(buffer);
 
         let this = Self {
+            peer_id,
             outlet,
             subscribers: <_>::default(),
             queue: <_>::default(),

--- a/connection-pool/src/behaviour.rs
+++ b/connection-pool/src/behaviour.rs
@@ -288,10 +288,10 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
 
         self.add_address(*peer_id, multiaddr.clone());
 
-        self.lifecycle_event(LifecycleEvent::Connected(Contact {
-            peer_id: *peer_id,
-            addr: multiaddr.into(),
-        }))
+        self.lifecycle_event(LifecycleEvent::Connected(Contact::new(
+            *peer_id,
+            vec![multiaddr],
+        )))
     }
 
     fn inject_addr_reach_failure(

--- a/connection-pool/src/connection_pool.rs
+++ b/connection-pool/src/connection_pool.rs
@@ -20,9 +20,12 @@ use particle_protocol::Particle;
 
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
+use itertools::Itertools;
 use libp2p::core::Multiaddr;
 use libp2p::PeerId;
+use serde::export::Formatter;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Contact {
@@ -37,6 +40,16 @@ impl Contact {
             peer_id,
             // TODO: take all addresses
             addr: addresses.into_iter().next(),
+        }
+    }
+}
+
+impl Display for Contact {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.addr.is_none() {
+            write!(f, "{} @ {}", self.peer_id, "[no addr]")
+        } else {
+            write!(f, "{} @ [{}]", self.peer_id, self.addr.iter().join(" "))
         }
     }
 }

--- a/connection-pool/src/connection_pool.rs
+++ b/connection-pool/src/connection_pool.rs
@@ -31,25 +31,22 @@ use std::fmt::Display;
 pub struct Contact {
     #[serde(with = "peerid_serializer")]
     pub peer_id: PeerId,
-    pub addr: Option<Multiaddr>,
+    pub addresses: Vec<Multiaddr>,
 }
 
 impl Contact {
     pub fn new(peer_id: PeerId, addresses: Vec<Multiaddr>) -> Self {
-        Self {
-            peer_id,
-            // TODO: take all addresses
-            addr: addresses.into_iter().next(),
-        }
+        Self { peer_id, addresses }
     }
 }
 
 impl Display for Contact {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.addr.is_none() {
+        if self.addresses.is_empty() {
             write!(f, "{} @ {}", self.peer_id, "[no addr]")
         } else {
-            write!(f, "{} @ [{}]", self.peer_id, self.addr.iter().join(" "))
+            let addrs = self.addresses.iter().join(" ");
+            write!(f, "{} @ [{}]", self.peer_id, addrs)
         }
     }
 }

--- a/crates/ctrlc-adapter/Cargo.toml
+++ b/crates/ctrlc-adapter/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 # the termination feature allows to handle both SIGTERM and SIGINT
 ctrlc = { version = "3.1.4", features = ["termination"] }
-async-std = "1.6.5"
+async-std = "1.9.0"
 futures = "0.3.5"

--- a/crates/kademlia/src/behaviour.rs
+++ b/crates/kademlia/src/behaviour.rs
@@ -53,6 +53,7 @@ pub enum PendingQuery {
     Unit(OneshotOutlet<Result<()>>),
 }
 
+#[derive(Debug)]
 struct PendingPeer {
     out: OneshotOutlet<Result<Vec<Multiaddr>>>,
     deadline: Instant,
@@ -231,7 +232,7 @@ impl Kademlia {
         // Remove empty keys
         self.pending_peers.retain(|_, peers| {
             // remove expired
-            let expired = peers.drain_filter(|p| p.deadline >= now);
+            let expired = peers.drain_filter(|p| p.deadline <= now);
             for p in expired {
                 // notify expired
                 p.out.send(Err(KademliaError::Timeout)).ok();

--- a/crates/kademlia/src/lib.rs
+++ b/crates/kademlia/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(drain_filter)]
 /*
  * Copyright 2020 Fluence Labs Limited
  *

--- a/crates/libp2p/Cargo.toml
+++ b/crates/libp2p/Cargo.toml
@@ -10,7 +10,7 @@ libp2p-secio = { package = "fluence-fork-libp2p-secio", version = "0.26.0" }
 multihash = { version = "0.13", features = ["serde-codec"] }
 futures = "0.3.5"
 futures-util = "0.3.5"
-async-std = "1.6.5"
+async-std = "1.9.0"
 
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.57"

--- a/crates/server-config/src/kademlia_config.rs
+++ b/crates/server-config/src/kademlia_config.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub struct KademliaConfig {
     pub max_packet_size: Option<usize>,
-    pub query_timeout: Option<Duration>,
+    pub query_timeout: Duration,
     pub replication_factor: Option<usize>,
     pub connection_idle_timeout: Option<Duration>,
 }
@@ -32,7 +32,7 @@ impl Default for KademliaConfig {
     fn default() -> Self {
         Self {
             max_packet_size: Some(100 * 4096 * 4096), // 100Mb
-            query_timeout: None,
+            query_timeout: Duration::from_secs(60),
             replication_factor: None,
             connection_idle_timeout: Some(Duration::from_secs(2_628_000_000)), // ~month
         }
@@ -43,12 +43,10 @@ impl Into<LibP2PKadConfig> for KademliaConfig {
     fn into(self) -> LibP2PKadConfig {
         let mut cfg = LibP2PKadConfig::default();
 
+        cfg.set_query_timeout(self.query_timeout);
+
         if let Some(max_packet_size) = self.max_packet_size {
             cfg.set_max_packet_size(max_packet_size);
-        }
-
-        if let Some(query_timeout) = self.query_timeout {
-            cfg.set_query_timeout(query_timeout);
         }
 
         if let Some(replication_factor) = self.replication_factor {

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -24,7 +24,7 @@ aquamarine-vm = "0.1.7"
 libp2p = { package = "fluence-fork-libp2p", version = "0.34.0" }
 
 rand = "0.7.3"
-async-std = "1.6.5"
+async-std = "1.9.0"
 futures = "0.3.5"
 futures-util = "0.3.5"
 serde_json = "1.0.57"

--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -128,9 +128,7 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
     fn neighborhood(&self, args: Args) -> Result<JValue, JError> {
         let key = from_base58("key", &mut args.function_args.into_iter())?;
         let key = Code::Sha2_256.digest(&key);
-        log::debug!(target: "debug_kademlia", "ask for neighboirhood");
         let neighbors = task::block_on(self.kademlia().neighborhood(key));
-        log::debug!(target: "debug_kademlia", "got neighborhood");
         let neighbors = neighbors
             .map(|vs| json!(vs.into_iter().map(|id| id.to_string()).collect::<Vec<_>>()))?;
 

--- a/particle-node/src/behaviour/network.rs
+++ b/particle-node/src/behaviour/network.rs
@@ -75,8 +75,11 @@ impl NetworkBehaviour {
         // TODO: this is hazy; names are bad, conversion is far from transparent. Hide behaviours?
         let kademlia = Kademlia::new(kad_config, cfg.trust_graph, cfg.registry.as_ref());
         let (kademlia_api, kademlia) = kademlia.into();
-        let (connection_pool, particle_stream) =
-            ConnectionPoolBehaviour::new(cfg.particle_queue_buffer, cfg.protocol_config);
+        let (connection_pool, particle_stream) = ConnectionPoolBehaviour::new(
+            cfg.particle_queue_buffer,
+            cfg.protocol_config,
+            cfg.local_peer_id,
+        );
         let (connection_pool_api, connection_pool) = connection_pool.into();
 
         let bootstrapper = Bootstrapper::new(cfg.bootstrap, cfg.local_peer_id, cfg.bootstrap_nodes);

--- a/particle-node/tests/echo_particle.rs
+++ b/particle-node/tests/echo_particle.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use test_utils::{enable_logs, make_swarms, ConnectedClient, KAD_TIMEOUT};
+use test_utils::{make_swarms, ConnectedClient, KAD_TIMEOUT};
 
 use maplit::hashmap;
 use serde_json::json;
@@ -22,8 +22,6 @@ use std::thread::sleep;
 
 #[test]
 fn echo_particle() {
-    enable_logs();
-
     let swarms = make_swarms(3);
     sleep(KAD_TIMEOUT);
     let mut client = ConnectedClient::connect_to(swarms[0].1.clone()).expect("connect client");

--- a/particle-node/tests/network_explore.rs
+++ b/particle-node/tests/network_explore.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 use test_utils::{
-    create_greeting_service, make_swarms, read_args, test_module, test_module_cfg, timeout,
-    ClientEvent, ConnectedClient, KAD_TIMEOUT,
+    create_greeting_service, enable_logs, make_swarms, read_args, test_module, test_module_cfg,
+    timeout, ClientEvent, ConnectedClient, KAD_TIMEOUT,
 };
 
 use futures::executor::block_on;
@@ -48,7 +48,9 @@ pub struct ModuleDescriptor {
 
 #[test]
 fn get_interfaces() {
-    let swarms = make_swarms(3);
+    enable_logs();
+
+    let swarms = make_swarms(10);
     sleep(KAD_TIMEOUT);
 
     let mut client = ConnectedClient::connect_to(swarms[0].1.clone()).expect("connect client");
@@ -145,7 +147,9 @@ fn get_blueprints() {
 
 #[test]
 fn explore_services() {
-    let swarms = make_swarms(10);
+    enable_logs();
+
+    let swarms = make_swarms(5);
     sleep(KAD_TIMEOUT);
 
     let mut client = ConnectedClient::connect_to(swarms[0].1.clone()).expect("connect client");

--- a/particle-protocol/Cargo.toml
+++ b/particle-protocol/Cargo.toml
@@ -21,4 +21,4 @@ bs58 = "0.4.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-async-std = "1.6.5"
+async-std = "1.9.0"

--- a/particle-protocol/src/libp2p_protocol/upgrade.rs
+++ b/particle-protocol/src/libp2p_protocol/upgrade.rs
@@ -162,7 +162,7 @@ where
 
             if log::max_level() >= LevelFilter::Debug {
                 match serde_json::to_string(&msg) {
-                    Ok(str) => log::debug!("Sending outbound ProtocolMessage: {}", str),
+                    Ok(str) => log::debug!("Sending ProtocolMessage: {}", str),
                     Err(err) => log::warn!("Can't serialize {:?} to string {}", &msg, err),
                 }
             }
@@ -174,7 +174,7 @@ where
             };
 
             let result = write().await.map_err(|err| {
-                log::warn!("Error sending outbound ProtocolMessage: {:?}", err);
+                log::warn!("Error sending ProtocolMessage: {:?}", err);
                 err
             });
 


### PR DESCRIPTION
Timeouts added to:

Connection Pool: 
- send, because libp2p can silently drop outbound messages

Kademlia:
- discover peer, because there's no guarantee that discovered peer will ever connect

I expect timeouts for all other methods to be already managed through libp2p. 