### PR TITLE
fix timestamp_ms execution problem, add test

### DIFF
--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -136,7 +136,7 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
             ("peer", "connect")               => wrap(self.connect(args)),
             ("peer", "get_contact")           => wrap_opt(self.get_contact(args)),
             ("peer", "identify")              => (self.identify)(args),
-            ("peer", "timestamp_ms")          => ok(json!(now_ms())),
+            ("peer", "timestamp_ms")          => ok(json!(now_ms() as u64)),
             ("peer", "timestamp_sec")         => ok(json!(now_sec())),
 
             ("kad", "neighborhood")           => wrap(self.neighborhood(args)),

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -200,7 +200,7 @@ fn timestamp_ms() {
         },
     );
 
-    let info = client.receive_args().wrap_err("receive args").unwrap();
-    let info = info.into_iter().next().unwrap();
-    let _: u64 = serde_json::from_value(info).unwrap();
+    let result = client.receive_args().wrap_err("receive args").unwrap();
+    let result = result.into_iter().next().unwrap();
+    let _: u64 = serde_json::from_value(result).unwrap();
 }

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -178,3 +178,29 @@ fn non_owner_remove_service() {
         panic!("incorrect args: expected two arrays, got: {:?}", args)
     }
 }
+
+#[test]
+fn timestamp_ms() {
+    let swarms = make_swarms(1);
+
+    let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
+        .wrap_err("connect client")
+        .unwrap();
+
+    client.send_particle(
+        r#"
+        (seq
+            (call relay ("peer" "timestamp_ms") [] result)
+            (call client ("op" "return") [result])
+        )
+        "#,
+        hashmap! {
+            "relay" => json!(client.node.to_string()),
+            "client" => json!(client.peer_id.to_string()),
+        },
+    );
+
+    let info = client.receive_args().wrap_err("receive args").unwrap();
+    let info = info.into_iter().next().unwrap();
+    let _: u64 = serde_json::from_value(info).unwrap();
+}

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -204,3 +204,29 @@ fn timestamp_ms() {
     let result = result.into_iter().next().unwrap();
     let _: u64 = serde_json::from_value(result).unwrap();
 }
+
+#[test]
+fn timestamp_sec() {
+    let swarms = make_swarms(1);
+
+    let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
+        .wrap_err("connect client")
+        .unwrap();
+
+    client.send_particle(
+        r#"
+        (seq
+            (call relay ("peer" "timestamp_sec") [] result)
+            (call client ("op" "return") [result])
+        )
+        "#,
+        hashmap! {
+            "relay" => json!(client.node.to_string()),
+            "client" => json!(client.peer_id.to_string()),
+        },
+    );
+
+    let result = client.receive_args().wrap_err("receive args").unwrap();
+    let result = result.into_iter().next().unwrap();
+    let _: u64 = serde_json::from_value(result).unwrap();
+}


### PR DESCRIPTION
Previously `("peer" "timestamp_ms")` execution failed with:
```
[2021-05-18T21:43:24.932946Z INFO  aquamarine::particle_executor] Executing particle 4d8cb775-3d73-4f42-84d4-fd2fd095a312
thread 'blocking-58' panicked at 'called `Result::unwrap()` on an `Err` value: Error("u128 is not supported", line: 0, column: 0)', /home/circleci/project/particle-closures/src/host_closures.rs:139:53
```