### PR TITLE
Add ops noop, concat, array; change op identity to return scalar

### DIFF
--- a/crates/host-closure/src/args_error.rs
+++ b/crates/host-closure/src/args_error.rs
@@ -16,7 +16,7 @@
 
 use json_utils::err_as_value;
 
-use serde_json::Value as JValue;
+use serde_json::{json, Value as JValue};
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -46,6 +46,12 @@ impl From<ArgsError> for JValue {
 /// An error that can be created from any other error
 /// Simplifies life by converting errors to be returnable from host closures
 pub struct JError(pub JValue);
+
+impl JError {
+    pub fn new(msg: impl AsRef<str>) -> Self {
+        Self(json!(msg.as_ref()))
+    }
+}
 
 impl From<JError> for JValue {
     fn from(err: JError) -> Self {

--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -170,7 +170,7 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
 
             ("op", "noop")                    => unit(),
             ("op", "array")                   => ok(Array(args.function_args)),
-            ("op", "identity")                => wrap_opt(Ok(args.function_args.into_iter().next())),
+            ("op", "identity")                => wrap_opt(self.identity(args.function_args)),
             ("op", "concat")                  => wrap(self.concat(args.function_args)),
             ("op", "string_to_b58")           => wrap(self.string_to_b58(args.function_args)),
             ("op", "string_from_b58")         => wrap(self.string_from_b58(args.function_args)),
@@ -378,6 +378,17 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
         };
 
         Ok(json!(keys))
+    }
+
+    fn identity(&self, args: Vec<serde_json::Value>) -> Result<Option<JValue>, JError> {
+        if args.len() > 1 {
+            Err(JError::new(format!(
+                "identity accepts up to 1 arguments, received {} arguments",
+                args.len()
+            )))
+        } else {
+            Ok(args.into_iter().next())
+        }
     }
 
     /// Flattens an array of arrays

--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -21,7 +21,7 @@ use connection_pool::{ConnectionPoolApi, ConnectionPoolT};
 use host_closure::{
     from_base58, Args, Closure, ClosureDescriptor, JError, ParticleClosure, ParticleParameters,
 };
-use ivalue_utils::{into_record, into_record_opt, ok, IValue};
+use ivalue_utils::{into_record, into_record_opt, ok, unit, IValue};
 use kademlia::{KademliaApi, KademliaApiT};
 use now_millis::{now_ms, now_sec};
 use particle_modules::ModuleRepository;
@@ -168,7 +168,9 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
             ("script", "remove")              => wrap(self.remove_script(args, params)),
             ("script", "list")                => wrap(self.list_scripts()),
 
-            ("op", "identity")                => ok(Array(args.function_args)),
+            ("op", "noop")                    => unit(),
+            ("op", "concat")                  => ok(Array(args.function_args)),
+            ("op", "identity")                => wrap_opt(Ok(args.function_args.into_iter().next())),
             ("op", "string_to_b58")           => wrap(self.string_to_b58(args.function_args)),
             ("op", "string_from_b58")         => wrap(self.string_from_b58(args.function_args)),
             ("op", "bytes_from_b58")          => wrap(self.bytes_from_b58(args.function_args)),

--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -382,19 +382,19 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
 
     /// Flattens an array of arrays
     fn concat(&self, args: Vec<serde_json::Value>) -> Result<JValue, JError> {
-        let flattened: Vec<JValue> = args.into_iter().enumerate().flat_map().try_fold(
-            vec![],
-            |mut acc, (i, mut v)| match v.take() {
-                JValue::Array(mut array) => {
-                    acc.append(&mut array);
-                    Ok(acc)
-                }
-                _ => Err(JError::new(format!(
-                    "all arguments of 'concat' must be arrays: argument #{} is not",
-                    i
-                ))),
-            },
-        )?;
+        let flattened: Vec<JValue> =
+            args.into_iter()
+                .enumerate()
+                .try_fold(vec![], |mut acc, (i, mut v)| match v.take() {
+                    JValue::Array(mut array) => {
+                        acc.append(&mut array);
+                        Ok(acc)
+                    }
+                    _ => Err(JError::new(format!(
+                        "all arguments of 'concat' must be arrays: argument #{} is not",
+                        i
+                    ))),
+                })?;
 
         Ok(JValue::Array(flattened))
     }

--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -382,19 +382,19 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
 
     /// Flattens an array of arrays
     fn concat(&self, args: Vec<serde_json::Value>) -> Result<JValue, JError> {
-        let flattened: Vec<JValue> =
-            args.into_iter()
-                .enumerate()
-                .try_fold(vec![], |mut acc, (i, mut v)| match v.take() {
-                    JValue::Array(mut array) => {
-                        acc.append(&mut array);
-                        Ok(acc)
-                    }
-                    _ => Err(JError::new(format!(
-                        "all arguments of 'concat' must be arrays: argument #{} wasn't",
-                        i
-                    ))),
-                })?;
+        let flattened: Vec<JValue> = args.into_iter().enumerate().flat_map().try_fold(
+            vec![],
+            |mut acc, (i, mut v)| match v.take() {
+                JValue::Array(mut array) => {
+                    acc.append(&mut array);
+                    Ok(acc)
+                }
+                _ => Err(JError::new(format!(
+                    "all arguments of 'concat' must be arrays: argument #{} is not",
+                    i
+                ))),
+            },
+        )?;
 
         Ok(JValue::Array(flattened))
     }

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -223,7 +223,6 @@ fn non_owner_remove_service() {
 
     use serde_json::Value::{Array, String};
 
-    println!("will receive");
     let args = dbg!(client2.receive_args().unwrap());
     if let [Array(before), Array(after), String(error)] = args.as_slice() {
         assert_eq!(before.len(), 1);

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -223,6 +223,7 @@ fn non_owner_remove_service() {
 
     use serde_json::Value::{Array, String};
 
+    println!("will receive");
     let args = dbg!(client2.receive_args().unwrap());
     if let [Array(before), Array(after), String(error)] = args.as_slice() {
         assert_eq!(before.len(), 1);

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -211,7 +211,7 @@ fn non_owner_remove_service() {
             )
             (seq
                 (call relay ("srv" "list") [] list_after)
-                (call %init_peer_id% ("op" "return") [list_before list_after error.$[0]!])
+                (call %init_peer_id% ("op" "return") [list_before list_after error])
             )
         )
     "#,
@@ -223,7 +223,7 @@ fn non_owner_remove_service() {
 
     use serde_json::Value::{Array, String};
 
-    let args = client2.receive_args().unwrap();
+    let args = dbg!(client2.receive_args().unwrap());
     if let [Array(before), Array(after), String(error)] = args.as_slice() {
         assert_eq!(before.len(), 1);
         assert_eq!(after.len(), 1);
@@ -543,11 +543,7 @@ fn neighborhood() {
         .expect("neighborhood is an array")
         .into_iter()
         .map(|v| PeerId::from_str(v.as_str().expect("peerid is string")).expect("peerid is valid"));
-    let error = into_array(result[2].take())
-        .expect("error is wrapped in array")
-        .into_iter()
-        .next()
-        .expect("error is defined");
+    let error = result[2].take();
     let error = error.as_str().expect("error is string");
     assert_eq!(neighborhood_by_key.len(), 1);
     assert_eq!(neighborhood_by_mhash.len(), 1);
@@ -630,8 +626,8 @@ fn ipfs_multiaddr() {
         true,
     );
 
-    let uninit_error = result[0].as_array().unwrap()[0].as_str().unwrap();
-    let cleared_error = result[3].as_array().unwrap()[0].as_str().unwrap();
+    let uninit_error = result[0].as_str().unwrap();
+    let cleared_error = result[3].as_str().unwrap();
 
     assert!(uninit_error.contains("ipfs multiaddr isn't set"));
     assert_eq!(result[1], json!(first_maddr));

--- a/particle-node/tests/builtin.rs
+++ b/particle-node/tests/builtin.rs
@@ -223,7 +223,7 @@ fn non_owner_remove_service() {
 
     use serde_json::Value::{Array, String};
 
-    let args = dbg!(client2.receive_args().unwrap());
+    let args = client2.receive_args().unwrap();
     if let [Array(before), Array(after), String(error)] = args.as_slice() {
         assert_eq!(before.len(), 1);
         assert_eq!(after.len(), 1);

--- a/particle-node/tests/network_explore.rs
+++ b/particle-node/tests/network_explore.rs
@@ -234,17 +234,13 @@ fn explore_services() {
                     )
                     (fold $neighs_inner ns
                         (seq
-                            ; HACK: convert ns from iterable to a value
-                            (null) ;(call relay ("op" "identity") [ns] ns_wrapped)
-                            (seq
-                                (fold ns n
-                                    (seq
-                                        (call n ("peer" "identify") [] $external_addresses)
-                                        (next n)
-                                    )
+                            (fold ns n
+                                (seq
+                                    (call n ("peer" "identify") [] $external_addresses)
+                                    (next n)
                                 )
-                                (next ns)
                             )
+                            (next ns)
                         )
                     )
                 )


### PR DESCRIPTION
`(op noop)` – always returns empty string (unit)
`(op array)` – accepts any number of arguments and wraps them in a single array
`(op concat)` – accepts any number of arrays and concatenates them
`(op identity)` – accepts at most 1 arguments and returns it; if no arguments, empty string (unit) is returned

### Types
```scala
Op.noop() -> ()
Op.array(args: any[]) -> any[]
Op.concat(args: any[][]) -> any[]
Op.identity(a: Option<any>) -> Option<any>
```
