### PR TITLE
Limit neighborhood nodes to K

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,9 +1595,8 @@ dependencies = [
 
 [[package]]
 name = "fluence-fork-libp2p"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776a8e1e7e983ff39fa6fb5fb53f5c48a34494d2f86e41a465db2099c5dbc5ee"
+version = "0.36.2"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
@@ -1610,7 +1609,7 @@ dependencies = [
  "fluence-fork-libp2p-kad",
  "fluence-fork-libp2p-mdns",
  "fluence-fork-libp2p-mplex",
- "fluence-fork-libp2p-noise",
+ "fluence-fork-libp2p-noise 0.29.1 (git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest)",
  "fluence-fork-libp2p-ping",
  "fluence-fork-libp2p-plaintext",
  "fluence-fork-libp2p-pnet",
@@ -1634,8 +1633,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-core"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ffef53cfb8b873bf75998669b0aedd5212907d29d8be8e7915c4695967c40d"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "asn1_der",
  "bs58 0.4.0",
@@ -1669,8 +1667,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-deflate"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488f08a680cd6ae739f51bd14ed8554a5aa66e97bd3f3c241675b8a2f60646"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "flate2",
  "fluence-fork-libp2p-core",
@@ -1680,8 +1677,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-dns"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72495d5c610a1a3ac8e25ae2e6714829bf7dfbba58aaa1a049f874c0e776ef0f"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "fluence-fork-libp2p-core",
  "futures",
@@ -1691,8 +1687,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-floodsub"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6443a1b325f2349b26182fd9673d84dbf9ceb67557452b6b49ff74c134f2478b"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "cuckoofilter",
  "fluence-fork-libp2p-core",
@@ -1709,8 +1704,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-gossipsub"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d33a3b3af8b3e6ffac876a146a56b4ed8d346505a71238369524ebf1d6e053e"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.0",
@@ -1735,8 +1729,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-identify"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7040dc82ea4141018438c7e0d0013d2875c586585a95158aa4ac35348bfc0d"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "fluence-fork-libp2p-core",
  "fluence-fork-libp2p-swarm",
@@ -1750,9 +1743,8 @@ dependencies = [
 
 [[package]]
 name = "fluence-fork-libp2p-kad"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d19bd700242b26c7966a9d1029379ec86a07d3ac2344bc02b4bb3e0bcf22f7"
+version = "0.29.2"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -1782,8 +1774,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-mdns"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c0ce999c0dbd7a8aa16bfa3381f359bf5e05d5e14d4e4c82ab5bef44bb2b49"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1803,8 +1794,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-mplex"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7558ff6d10a80d5e344e07a211ef629bdc4d264479a2b16f5aec711fc6f3afac"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
@@ -1816,6 +1806,27 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.0",
+]
+
+[[package]]
+name = "fluence-fork-libp2p-noise"
+version = "0.29.1"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+dependencies = [
+ "bytes 1.0.1",
+ "curve25519-dalek",
+ "fluence-fork-libp2p-core",
+ "futures",
+ "lazy_static",
+ "log",
+ "prost 0.7.0",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.9.5",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1843,8 +1854,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-ping"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75526a211afefb16b4700fc0c5b688b3efbd07900fc772e48245ef00d4ec3f5c"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "fluence-fork-libp2p-core",
  "fluence-fork-libp2p-swarm",
@@ -1858,8 +1868,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-plaintext"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b02f398352d700e07463d542c44e1acb96c792bf4ce761af9746688acbdcc38"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
@@ -1875,8 +1884,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-pnet"
 version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530f5bab1797304462d3a50a4099ba8cd455b52321518454b81e23c2dc2a406a"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "futures",
  "log",
@@ -1889,8 +1897,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-request-response"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fc030527285042d615c6af944b50a792ef5f6599cd4f05189fa7516b66d83f"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
@@ -1909,8 +1916,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-swarm"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e63687c78866dce48b338f974362b0f2d798371f5c3023b03a8ee37a1f77a77"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "either",
  "fluence-fork-libp2p-core",
@@ -1925,8 +1931,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-swarm-derive"
 version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa8eac07f6dbcbef6ca320a501d9c2f90913b9e728e973037c197041daa6152"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "quote",
  "syn",
@@ -1935,8 +1940,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-tcp"
 version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7a6ed7fed69022e5d5497db5ac18db5af141aa14f495e3cb3648294cacf2f4"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "async-io",
  "fluence-fork-libp2p-core",
@@ -1954,8 +1958,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-uds"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05722ed48540139d30c3eacd2f184f4e63b1468a884ceb2da7db19bad1a4929"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "async-std",
  "fluence-fork-libp2p-core",
@@ -1966,8 +1969,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-wasm-ext"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fccdaff9101ff84ca2dde530168c25c2d9d5e6826d03aea806fa8b1bf4b92fbc"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "fluence-fork-libp2p-core",
  "futures",
@@ -1980,8 +1982,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-websocket"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb77c1c332d5a128c3fdd322d159871d4ef7c9aa881bff2728a1a6c08badeee"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "either",
  "fluence-fork-libp2p-core",
@@ -1998,8 +1999,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-yamux"
 version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fd46cde3155d72fb9f10c115e577f47a96f279aa1c25e216c36ea2d5d692d5"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "fluence-fork-libp2p-core",
  "futures",
@@ -2011,8 +2011,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-multistream-select"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34dacd25fddb6fed5c3fa6109fb29e4eea49b731a2548e09f4e54620fa4d6310"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "bytes 1.0.1",
  "futures",
@@ -2025,8 +2024,7 @@ dependencies = [
 [[package]]
 name = "fluence-fork-parity-multiaddr"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06228daafbf129ef49806f15779857012c01d49658930d086498e78f12191da7"
+source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
 dependencies = [
  "arrayref",
  "bs58 0.4.0",
@@ -2086,7 +2084,7 @@ dependencies = [
  "bs58 0.3.1",
  "failure",
  "fluence-fork-libp2p",
- "fluence-fork-libp2p-noise",
+ "fluence-fork-libp2p-noise 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "futures-util",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p"
 version = "0.36.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc81dc6d89ac9c706b058ca9d9f2fc2fa71680accd3e191c1e812e1832658ca"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
@@ -1609,7 +1610,7 @@ dependencies = [
  "fluence-fork-libp2p-kad",
  "fluence-fork-libp2p-mdns",
  "fluence-fork-libp2p-mplex",
- "fluence-fork-libp2p-noise 0.29.1 (git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest)",
+ "fluence-fork-libp2p-noise",
  "fluence-fork-libp2p-ping",
  "fluence-fork-libp2p-plaintext",
  "fluence-fork-libp2p-pnet",
@@ -1633,7 +1634,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-core"
 version = "0.27.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ffef53cfb8b873bf75998669b0aedd5212907d29d8be8e7915c4695967c40d"
 dependencies = [
  "asn1_der",
  "bs58 0.4.0",
@@ -1667,7 +1669,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-deflate"
 version = "0.27.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6488f08a680cd6ae739f51bd14ed8554a5aa66e97bd3f3c241675b8a2f60646"
 dependencies = [
  "flate2",
  "fluence-fork-libp2p-core",
@@ -1677,7 +1680,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-dns"
 version = "0.27.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72495d5c610a1a3ac8e25ae2e6714829bf7dfbba58aaa1a049f874c0e776ef0f"
 dependencies = [
  "fluence-fork-libp2p-core",
  "futures",
@@ -1687,7 +1691,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-floodsub"
 version = "0.28.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6443a1b325f2349b26182fd9673d84dbf9ceb67557452b6b49ff74c134f2478b"
 dependencies = [
  "cuckoofilter",
  "fluence-fork-libp2p-core",
@@ -1704,7 +1709,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-gossipsub"
 version = "0.29.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d33a3b3af8b3e6ffac876a146a56b4ed8d346505a71238369524ebf1d6e053e"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.0",
@@ -1729,7 +1735,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-identify"
 version = "0.28.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7040dc82ea4141018438c7e0d0013d2875c586585a95158aa4ac35348bfc0d"
 dependencies = [
  "fluence-fork-libp2p-core",
  "fluence-fork-libp2p-swarm",
@@ -1744,7 +1751,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-kad"
 version = "0.29.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108d0f7ce75ba01d3f2ab0c5490edfe0fad5b355609523762773a2f9af8660bd"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -1774,7 +1782,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-mdns"
 version = "0.29.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c0ce999c0dbd7a8aa16bfa3381f359bf5e05d5e14d4e4c82ab5bef44bb2b49"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1794,7 +1803,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-mplex"
 version = "0.27.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7558ff6d10a80d5e344e07a211ef629bdc4d264479a2b16f5aec711fc6f3afac"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
@@ -1806,27 +1816,6 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.0",
-]
-
-[[package]]
-name = "fluence-fork-libp2p-noise"
-version = "0.29.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
-dependencies = [
- "bytes 1.0.1",
- "curve25519-dalek",
- "fluence-fork-libp2p-core",
- "futures",
- "lazy_static",
- "log",
- "prost 0.7.0",
- "prost-build",
- "rand 0.7.3",
- "sha2 0.9.5",
- "snow",
- "static_assertions",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
@@ -1854,7 +1843,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-ping"
 version = "0.28.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75526a211afefb16b4700fc0c5b688b3efbd07900fc772e48245ef00d4ec3f5c"
 dependencies = [
  "fluence-fork-libp2p-core",
  "fluence-fork-libp2p-swarm",
@@ -1868,7 +1858,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-plaintext"
 version = "0.27.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b02f398352d700e07463d542c44e1acb96c792bf4ce761af9746688acbdcc38"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
@@ -1884,7 +1875,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-pnet"
 version = "0.20.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "530f5bab1797304462d3a50a4099ba8cd455b52321518454b81e23c2dc2a406a"
 dependencies = [
  "futures",
  "log",
@@ -1897,7 +1889,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-request-response"
 version = "0.10.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fc030527285042d615c6af944b50a792ef5f6599cd4f05189fa7516b66d83f"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
@@ -1916,7 +1909,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-swarm"
 version = "0.28.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e63687c78866dce48b338f974362b0f2d798371f5c3023b03a8ee37a1f77a77"
 dependencies = [
  "either",
  "fluence-fork-libp2p-core",
@@ -1931,7 +1925,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-swarm-derive"
 version = "0.22.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa8eac07f6dbcbef6ca320a501d9c2f90913b9e728e973037c197041daa6152"
 dependencies = [
  "quote",
  "syn",
@@ -1940,7 +1935,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-tcp"
 version = "0.27.3"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7a6ed7fed69022e5d5497db5ac18db5af141aa14f495e3cb3648294cacf2f4"
 dependencies = [
  "async-io",
  "fluence-fork-libp2p-core",
@@ -1958,7 +1954,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-uds"
 version = "0.27.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05722ed48540139d30c3eacd2f184f4e63b1468a884ceb2da7db19bad1a4929"
 dependencies = [
  "async-std",
  "fluence-fork-libp2p-core",
@@ -1969,7 +1966,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-wasm-ext"
 version = "0.27.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fccdaff9101ff84ca2dde530168c25c2d9d5e6826d03aea806fa8b1bf4b92fbc"
 dependencies = [
  "fluence-fork-libp2p-core",
  "futures",
@@ -1982,7 +1980,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-websocket"
 version = "0.28.1"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb77c1c332d5a128c3fdd322d159871d4ef7c9aa881bff2728a1a6c08badeee"
 dependencies = [
  "either",
  "fluence-fork-libp2p-core",
@@ -1999,7 +1998,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-libp2p-yamux"
 version = "0.30.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fd46cde3155d72fb9f10c115e577f47a96f279aa1c25e216c36ea2d5d692d5"
 dependencies = [
  "fluence-fork-libp2p-core",
  "futures",
@@ -2011,7 +2011,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-multistream-select"
 version = "0.10.3"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34dacd25fddb6fed5c3fa6109fb29e4eea49b731a2548e09f4e54620fa4d6310"
 dependencies = [
  "bytes 1.0.1",
  "futures",
@@ -2024,7 +2025,8 @@ dependencies = [
 [[package]]
 name = "fluence-fork-parity-multiaddr"
 version = "0.11.2"
-source = "git+https://github.com/fluencelabs/rust-libp2p?branch=k_closest#e2b0431c66daf1447340da4e43897cb1e1926dbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06228daafbf129ef49806f15779857012c01d49658930d086498e78f12191da7"
 dependencies = [
  "arrayref",
  "bs58 0.4.0",
@@ -2084,7 +2086,7 @@ dependencies = [
  "bs58 0.3.1",
  "failure",
  "fluence-fork-libp2p",
- "fluence-fork-libp2p-noise 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluence-fork-libp2p-noise",
  "futures",
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,3 @@ members = [
 exclude = [
     "particle-node/tests/tetraplets",
 ]
-
-[patch.crates-io]
-libp2p = { package = "fluence-fork-libp2p", git = 'https://github.com/fluencelabs/rust-libp2p', branch = 'k_closest' }
-libp2p-core = { package = "fluence-fork-libp2p-core", git = 'https://github.com/fluencelabs/rust-libp2p', branch = 'k_closest' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ members = [
 exclude = [
     "particle-node/tests/tetraplets",
 ]
+
+[patch.crates-io]
+libp2p = { package = "fluence-fork-libp2p", git = 'https://github.com/fluencelabs/rust-libp2p', branch = 'k_closest' }
+libp2p-core = { package = "fluence-fork-libp2p-core", git = 'https://github.com/fluencelabs/rust-libp2p', branch = 'k_closest' }

--- a/aquamarine/Cargo.toml
+++ b/aquamarine/Cargo.toml
@@ -13,7 +13,7 @@ host-closure = { path = "../crates/host-closure" }
 control-macro = { path = "../crates/control-macro" }
 
 avm-server = "0.7.0"
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 futures = "0.3.13"
 log = "0.4.11"

--- a/client/rust-libp2p/Cargo.toml
+++ b/client/rust-libp2p/Cargo.toml
@@ -9,7 +9,7 @@ particle-protocol = { path = "../../particle-protocol" }
 fluence-libp2p = { path = "../../crates/libp2p" }
 ctrlc-adapter = { path = "../../crates/ctrlc-adapter"}
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 multihash ="0.13"
 async-std = "1.9.0"

--- a/connection-pool/Cargo.toml
+++ b/connection-pool/Cargo.toml
@@ -9,7 +9,7 @@ particle-protocol = { path = "../particle-protocol"}
 trust-graph = "0.2.7"
 fluence-libp2p = { path = "../crates/libp2p" }
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 futures = "0.3.13"
 log = "0.4.13"

--- a/crates/kademlia/Cargo.toml
+++ b/crates/kademlia/Cargo.toml
@@ -13,7 +13,7 @@ waiting-queues = { path = "../waiting-queues" }
 fluence-libp2p = { path = "../libp2p" }
 server-config = { path = "../server-config" }
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 multihash = "0.13.2"
 once_cell = "1.4.1"

--- a/crates/kademlia/src/api.rs
+++ b/crates/kademlia/src/api.rs
@@ -37,7 +37,7 @@ pub trait KademliaApiT {
     fn add_contact(&self, contact: Contact) -> bool;
     fn local_lookup(&self, peer: PeerId) -> Future<Result<Vec<Multiaddr>>>;
     fn discover_peer(&self, peer: PeerId) -> Future<Result<Vec<Multiaddr>>>;
-    fn neighborhood(&self, key: Multihash) -> Future<Result<Vec<PeerId>>>;
+    fn neighborhood(&self, key: Multihash, count: usize) -> Future<Result<Vec<PeerId>>>;
 }
 
 // marked `pub` to be available in benchmarks
@@ -59,6 +59,7 @@ pub enum Command {
     },
     Neighborhood {
         key: Multihash,
+        count: usize,
         out: OneshotOutlet<Result<Vec<PeerId>>>,
     },
 }
@@ -95,7 +96,9 @@ impl KademliaApiInlet {
             Command::Bootstrap { out } => self.kademlia.bootstrap(out),
             Command::LocalLookup { peer, out } => self.kademlia.local_lookup(&peer, out),
             Command::DiscoverPeer { peer, out } => self.kademlia.discover_peer(peer, out),
-            Command::Neighborhood { key, out } => self.kademlia.neighborhood(key, out),
+            Command::Neighborhood { key, count, out } => {
+                self.kademlia.neighborhood(key, count, out)
+            }
         }
     }
 
@@ -179,7 +182,7 @@ impl KademliaApiT for KademliaApi {
         self.execute(|out| Command::DiscoverPeer { peer, out })
     }
 
-    fn neighborhood(&self, key: Multihash) -> Future<Result<Vec<PeerId>>> {
-        self.execute(|out| Command::Neighborhood { key, out })
+    fn neighborhood(&self, key: Multihash, count: usize) -> Future<Result<Vec<PeerId>>> {
+        self.execute(|out| Command::Neighborhood { key, count, out })
     }
 }

--- a/crates/kademlia/src/behaviour.rs
+++ b/crates/kademlia/src/behaviour.rs
@@ -219,9 +219,16 @@ impl Kademlia {
         }
     }
 
-    pub fn neighborhood(&mut self, key: Multihash, outlet: OneshotOutlet<Result<Vec<PeerId>>>) {
-        let peers = self.kademlia.local_closest_peers(key);
-        let peers = peers.into_iter().map(|p| p.peer_id.into_preimage());
+    pub fn neighborhood(
+        &mut self,
+        key: Multihash,
+        count: usize,
+        outlet: OneshotOutlet<Result<Vec<PeerId>>>,
+    ) {
+        let key = key.into();
+        let peers = self.kademlia.local_closest_peers(&key);
+        let peers = peers.take(count);
+        let peers = peers.map(|p| p.peer_id.into_preimage());
         outlet.send(Ok(peers.collect())).ok();
         self.wake();
     }

--- a/crates/libp2p/Cargo.toml
+++ b/crates/libp2p/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 libp2p-noise = { package = "fluence-fork-libp2p-noise", version = "0.29.0" }
 multihash = { version = "0.13", features = ["serde-codec"] }
 futures = "0.3.13"

--- a/crates/server-config/Cargo.toml
+++ b/crates/server-config/Cargo.toml
@@ -13,7 +13,7 @@ trust-graph = "0.2.7"
 fluence-identity = "0.3.0"
 air-interpreter-wasm = "0.9.14"
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 serde = { version = "1.0.118", features = ["derive"] }
 humantime-serde = "1.0.1"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -24,7 +24,7 @@ avm-server = "0.7.0"
 fluence-identity = "0.3.0"
 fluence-faas = "0.7.0"
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 rand = "0.7.3"
 async-std = "1.9.0"

--- a/particle-closures/Cargo.toml
+++ b/particle-closures/Cargo.toml
@@ -23,7 +23,7 @@ waiting-queues = { path = "../crates/waiting-queues" }
 async-unlock = { path = "../crates/async-unlock" }
 now-millis = { path = "../crates/now-millis" }
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 trust-graph = "0.2.7"
 fluence-identity = "0.3.0"
 

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -24,7 +24,7 @@ trust-graph = "0.2.7"
 fluence-identity = "0.3.0"
 air-interpreter-wasm = "0.9.14"
 
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 multihash ="0.13"
 futures = "0.3.13"
 futures-util = "0.3.5"

--- a/particle-protocol/Cargo.toml
+++ b/particle-protocol/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Fluence Labs"]
 edition = "2018"
 
 [dependencies]
-libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
+libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 fluence-libp2p = { path = "../crates/libp2p" }
 json-utils = { path = "../crates/json-utils" }
 now-millis = { path = "../crates/now-millis" }


### PR DESCRIPTION
fixes #1113 

## Builtin API change: kad neighborhood
neighborhood now accepts third parameter: 
`count` - optional number, defaults to 20. If set, used as a limit to the number of returned nodes