### PR TITLE
Builtins: support array-backed options

### DIFF
--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -100,7 +100,7 @@ impl Args {
     }
 
     /// Retrieves a json value from iterator if it's not empty, and parses it to Aqua's option representation
-    /// Aqua's option is expected to be backed by an array of 1 or 0 elements.
+    /// Aqua's option is expected to be an array of 1 or 0 elements.
     /// For the sakes of backward compatibility, scalar value and absence of value are tolerated as well.
     /// `field` is to generate a more accurate error message
     pub fn next_opt<T: for<'de> Deserialize<'de>>(

--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -113,9 +113,8 @@ impl Args {
             // then, depending on T, it may be one of:
             //    - Some(array) if T is an array
             //    - invalid option if T is a scalar (because you can't deserialize several values as a scalar)
-            // The only way to tell one from the other is by looking at the return type.
-            //
-            // So that's what is done here:
+            // The only way to tell one from the other is by looking at the T.
+            // And that's what is done here:
             // keep value untouched, so T can deserialize itself and fail as needed
             JValue::Array(values) if values.len() > 1 => JValue::Array(values),
             // Option backed by array of 1 or 0 elements

--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -118,9 +118,11 @@ impl Args {
             // So that's what is done here:
             // keep value untouched, so T can deserialize itself and fail as needed
             JValue::Array(values) if values.len() > 1 => JValue::Array(values),
+            // Option backed by array of 1 or 0 elements
             JValue::Array(values) => {
                 ok_get!(values.into_iter().next())
             }
+            // Scalar value
             value => value,
         };
 

--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -140,15 +140,16 @@ mod tests {
 
     #[test]
     fn test_next_opt() {
+        #[rustfmt::skip]
         let mut args = vec![
-            json!([]),           // None
-            json!(["hi"]),       // Some String
-            json!(["hi", "hi"]), // Some Vec
-            json!([]),           // None Vec
-            json!(["hi", "hi"]), // Error
-            json!("hi"),         // Some String
-                                 // None String
-                                 // None Vec
+            json!([]),           // as String => None
+            json!(["hi"]),       // as String => Some
+            json!(["hi", "hi"]), // as Vec    => Some
+            json!([]),           // as Vec    => None
+            json!(["hi", "hi"]), // as String => Error
+            json!("hi"),         // as String => Some
+            /* absence */        // as String => None
+            /* absence */        // as Vec    => None
         ]
         .into_iter();
 

--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -109,10 +109,12 @@ impl Args {
     ) -> Result<Option<T>, ArgsError> {
         let value = ok_get!(args.next());
         let value = match value {
-            // If there are several values in the passed array,
-            // then that could be either a Some(array) in scalar form or an invalid option.
+            // If there is more than 1 value in the passed array
+            // then depending on T it may be one of:
+            //    - Some(array) if T is an array
+            //    - invalid option if T is a scalar (because you can't deserialize several values as a scalar)
             // The only way to tell one from the other is by looking at the return type.
-            // So that's exactly what I do here: asking T to deserialize itself.
+            // So that's exactly what I do here: asking T to deserialize itself and let it fail.
             JValue::Array(values) if values.len() > 1 => JValue::Array(values),
             JValue::Array(values) => {
                 ok_get!(values.into_iter().next())

--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -110,11 +110,13 @@ impl Args {
         let value = ok_get!(args.next());
         let value = match value {
             // If there is more than 1 value in the passed array
-            // then depending on T it may be one of:
+            // then, depending on T, it may be one of:
             //    - Some(array) if T is an array
             //    - invalid option if T is a scalar (because you can't deserialize several values as a scalar)
             // The only way to tell one from the other is by looking at the return type.
-            // So that's exactly what I do here: asking T to deserialize itself and let it fail.
+            //
+            // So that's what is done here:
+            // keep value untouched, so T can deserialize itself and fail as needed
             JValue::Array(values) if values.len() > 1 => JValue::Array(values),
             JValue::Array(values) => {
                 ok_get!(values.into_iter().next())

--- a/crates/host-closure/src/args.rs
+++ b/crates/host-closure/src/args.rs
@@ -103,6 +103,11 @@ impl Args {
     /// Aqua's option is expected to be an array of 1 or 0 elements.
     /// For the sakes of backward compatibility, scalar value and absence of value are tolerated as well.
     /// `field` is to generate a more accurate error message
+    ///
+    /// In short, function returns:
+    /// - if args is `[T]` or `[ [T] ]`         => Some(T)
+    /// - if args is `[]` or `[ [] ]`           => None
+    /// - if args contains more than 1 element  => error
     pub fn next_opt<T: for<'de> Deserialize<'de>>(
         field: &'static str,
         args: &mut impl Iterator<Item = JValue>,

--- a/crates/host-closure/src/args_error.rs
+++ b/crates/host-closure/src/args_error.rs
@@ -34,6 +34,8 @@ pub enum ArgsError {
         field: &'static str,
         err: Cow<'static, str>,
     },
+    #[error("Option's array must contain at most 1 element, {field} was of {length} elements")]
+    NonUnaryOption { field: &'static str, length: usize },
 }
 
 impl From<ArgsError> for JValue {

--- a/particle-closures/src/host_closures.rs
+++ b/particle-closures/src/host_closures.rs
@@ -195,8 +195,8 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
     fn neighborhood(&self, args: Args) -> Result<JValue, JError> {
         let mut args = args.function_args.into_iter();
         let key = from_base58("key", &mut args)?;
-        let already_hashed: Option<bool> = Args::maybe_next("already_hashed", &mut args)?;
-        let count: Option<usize> = Args::maybe_next("count", &mut args)?;
+        let already_hashed: Option<bool> = Args::next_opt("already_hashed", &mut args)?;
+        let count: Option<usize> = Args::next_opt("count", &mut args)?;
         let count = count.unwrap_or(K_VALUE.get());
 
         let key = if already_hashed == Some(true) {
@@ -223,7 +223,7 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
 
         let peer_id: String = Args::next("peer_id", &mut args)?;
         let peer_id = PeerId::from_str(peer_id.as_str())?;
-        let addrs: Vec<Multiaddr> = Args::maybe_next("addresses", &mut args)?.unwrap_or_default();
+        let addrs: Vec<Multiaddr> = Args::next_opt("addresses", &mut args)?.unwrap_or_default();
 
         let contact = Contact::new(peer_id, addrs);
 
@@ -245,7 +245,7 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
         let mut args = args.function_args.into_iter();
 
         let script: String = Args::next("script", &mut args)?;
-        let interval = Args::maybe_next("interval_sec", &mut args)?;
+        let interval = Args::next_opt("interval_sec", &mut args)?;
         let interval = interval
             .map(|s: String| s.parse::<u64>())
             .transpose()
@@ -329,8 +329,8 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
     fn sha256_string(&self, args: Vec<serde_json::Value>) -> Result<JValue, JError> {
         let mut args = args.into_iter();
         let string: String = Args::next("string", &mut args)?;
-        let digest_only: Option<bool> = Args::maybe_next("digest_only", &mut args)?;
-        let as_bytes: Option<bool> = Args::maybe_next("as_bytes", &mut args)?;
+        let digest_only: Option<bool> = Args::next_opt("digest_only", &mut args)?;
+        let as_bytes: Option<bool> = Args::next_opt("as_bytes", &mut args)?;
         let multihash: MultihashGeneric<_> = Code::Sha2_256.digest(string.as_bytes());
 
         let result = if digest_only == Some(true) {
@@ -354,7 +354,7 @@ impl<C: Clone + Send + Sync + 'static + AsRef<KademliaApi> + AsRef<ConnectionPoo
         let target: String = Args::next("target", &mut args)?;
         let left: Vec<String> = Args::next("left", &mut args)?;
         let right: Vec<String> = Args::next("right", &mut args)?;
-        let count: Option<usize> = Args::maybe_next("count", &mut args)?;
+        let count: Option<usize> = Args::next_opt("count", &mut args)?;
 
         let target = bs58::decode(target).into_vec().map_err(DecodeBase58)?;
         let target = Key::from(target);


### PR DESCRIPTION
Now optional arguments are treated in the following way:
- if args is `[T]` or `[ [T] ]`         => Some(T)
- if args is `[]` or `[ [] ]`           => None
- if args contains more than 1 element  => error