### PR TITLE
Log server peer id earlier

### DIFF
--- a/crates/server-config/src/listen_config.rs
+++ b/crates/server-config/src/listen_config.rs
@@ -19,28 +19,22 @@ use libp2p::multiaddr::Protocol;
 
 use std::net::IpAddr;
 
-#[derive(Copy, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ListenConfig {
-    pub listen_ip: IpAddr,
-    pub tcp_port: u16,
-    pub websocket_port: u16,
+    pub multiaddrs: Vec<Multiaddr>,
 }
 
 impl ListenConfig {
-    pub fn multiaddrs(&self) -> Vec<Multiaddr> {
-        let mut tcp = Multiaddr::from(self.listen_ip);
-        tcp.push(Protocol::Tcp(self.tcp_port));
+    pub fn new(listen_ip: IpAddr, tcp_port: u16, websocket_port: u16) -> Self {
+        let mut tcp = Multiaddr::from(listen_ip);
+        tcp.push(Protocol::Tcp(tcp_port));
 
-        let mut ws = Multiaddr::from(self.listen_ip);
-        ws.push(Protocol::Tcp(self.websocket_port));
+        let mut ws = Multiaddr::from(listen_ip);
+        ws.push(Protocol::Tcp(websocket_port));
         ws.push(Protocol::Ws("/".into()));
 
-        vec![tcp, ws]
-    }
-}
-
-impl From<&ListenConfig> for Vec<Multiaddr> {
-    fn from(cfg: &ListenConfig) -> Self {
-        cfg.multiaddrs()
+        Self {
+            multiaddrs: vec![tcp, ws],
+        }
     }
 }

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -71,7 +71,7 @@ pub struct NodeConfig {
 
     /// Number of stepper VMs to create. By default, `num_cpus::get() * 2` is used
     #[serde(default = "default_stepper_pool_size")]
-    pub stepper_pool_size: usize,
+    pub aquavm_pool_size: usize,
 
     #[serde(default)]
     pub kademlia: KademliaConfig,

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -153,11 +153,7 @@ impl ResolvedConfig {
     }
 
     pub fn listen_config(&self) -> ListenConfig {
-        ListenConfig {
-            listen_ip: self.listen_ip,
-            tcp_port: self.tcp_port,
-            websocket_port: self.websocket_port,
-        }
+        ListenConfig::new(self.listen_ip, self.tcp_port, self.websocket_port)
     }
 }
 

--- a/deploy/Config.default.toml
+++ b/deploy/Config.default.toml
@@ -9,7 +9,7 @@ root_key_pair.generate_on_absence = true
 ## Services will store their data here
 # default is /.fluence/v1/services
 # services_base_dir = "./services"
-## AIR Interpreter (stepper) will store its data here
+## AIR Interpreter will store its data here. NOTE: 'stepper' is an old name for interpreter.
 # default is /.fluence/v1/stepper
 # avm_base_dir = "./stepper"
 ## directory for TrustGraph certificates
@@ -42,7 +42,7 @@ bootstrap_nodes = [
 websocket_port = 9999
 #external_address = "85.85.35.35"
 prometheus_port = 18080
-stepper_pool_size = 16
+aquavm_pool_size = 16
 
 ## environment variables that will be passed to each service
 ## TODO: separate by service or move to service config

--- a/deploy/compose.py
+++ b/deploy/compose.py
@@ -32,8 +32,8 @@ CONFIG = {
             'command': '-c /Config.toml -f ed25519 -k {keypair} -x {host} -t {tcp_port} -w {ws_port} -m {management_key}',
             'volumes': ['{container_name}:/.fluence'],
             'container_name': '{container_name}',
-            'image': 'fluencelabs/fluence:{container_tag}',
-            'ports': ['{tcp_port}:{tcp_port}', '{ws_port}:{ws_port}'],
+            'image': 'fluencelabs/node:{container_tag}',
+            'ports': ['{tcp_port}:{tcp_port}', '{ws_port}:{ws_port}', '{ipfs_port}:5001'],
             'restart': 'always'
         }
     },
@@ -50,10 +50,12 @@ def gen_compose_file(out, container_tag, scale, is_bootstrap, bootstraps, host, 
         container = 'fluence_bootstrap'
         tcp_port = 7770
         ws_port = 9990
+        ipfs_port = 5550
     else:
         container = 'fluence'
         tcp_port = 7001
         ws_port = 9001
+        ipfs_port = 5001
 
     config = copy.deepcopy(CONFIG)
     service = config['services']['fluence']
@@ -85,14 +87,17 @@ def gen_compose_file(out, container_tag, scale, is_bootstrap, bootstraps, host, 
 
         container_config['ports'] = map(lambda p: p.format(
             tcp_port=tcp_port,
-            ws_port=ws_port
+            ws_port=ws_port,
+            ipfs_port=ipfs_port
         ), container_config['ports'])
         config['volumes'][container_name] = None
 
         tcp_port += 1
         ws_port += 1
+        ipfs_port += 1
 
-    puts("Writing config to {}:\n{}".format(out, yaml.dump(config)))
-    run('rm {} || true'.format(out))
-    append(out, yaml.dump(config))
+    puts("Writing config to {}".format(out))
+    with hide('running'):
+        run('rm {} || true'.format(out))
+        append(out, yaml.dump(config))
 

--- a/deploy/fluence.py
+++ b/deploy/fluence.py
@@ -96,7 +96,7 @@ def do_deploy_fluence(yml="fluence.yml"):
         compose('up --no-start', yml)  # was: 'create'
         copy_configs(yml)
         compose("restart", yml)
-        sleep(1)
+        sleep(5)
         addrs = get_fluence_addresses(yml)
         return addrs
 
@@ -147,7 +147,7 @@ def get_ports(container):
 
 
 def get_fluence_peer_ids(container, yml="fluence.yml"):
-    logs = run('docker logs %s' % container).splitlines()
+    logs = run('docker logs --tail 10000 %s' % container).splitlines()
     return parse_peer_ids(logs)
 
 

--- a/particle-node/tests/aqua_dht/aqua_dht.rs
+++ b/particle-node/tests/aqua_dht/aqua_dht.rs
@@ -16,10 +16,10 @@
 
 use connected_client::ConnectedClient;
 use created_swarm::make_swarms_with_builtins;
-use eyre::{ContextCompat, WrapErr};
+
+use eyre::WrapErr;
 use maplit::hashmap;
 use serde_json::json;
-use service_modules::{load_module, module_config};
 use std::path::Path;
 
 fn load_script(name: &str) -> String {


### PR DESCRIPTION
On deploy, it become hard to actually get `server peer id` from logs. So I put that log earlier.