### PR TITLE
Particle Data Store: fix cleanup function

### DIFF
--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use avm_server::DataStore;
 use thiserror::Error;
 
-use fs_utils::{create_dir, remove_dir, remove_file};
+use fs_utils::{create_dir, remove_file};
 use particle_execution::{ParticleVault, VaultError};
 use DataStoreError::{CleanupData, CreateDataStore, StoreData};
 

--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use avm_server::DataStore;
 use thiserror::Error;
 
-use fs_utils::{create_dir, remove_dir};
+use fs_utils::{create_dir, remove_dir, remove_file};
 use particle_execution::{ParticleVault, VaultError};
 use DataStoreError::{CleanupData, CreateDataStore, StoreData};
 
@@ -74,7 +74,7 @@ impl DataStore<DataStoreError> for ParticleDataStore {
     }
 
     fn cleanup_data(&mut self, key: &str) -> Result<()> {
-        remove_dir(&self.data_file(key)).map_err(CleanupData)?;
+        remove_file(&self.data_file(key)).map_err(CleanupData)?;
         self.vault.cleanup(key)?;
 
         Ok(())

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -31,6 +31,7 @@ use rand::Rng;
 use std::fmt::Debug;
 use std::fs;
 use std::fs::Permissions;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 pub fn to_abs_path(path: PathBuf) -> PathBuf {
@@ -106,21 +107,27 @@ where
 }
 
 pub fn remove_dir(dir: &Path) -> Result<(), std::io::Error> {
-    std::fs::remove_dir_all(dir).map_err(|err| {
-        std::io::Error::new(
+    match std::fs::remove_dir_all(dir) {
+        Ok(_) => Ok(()),
+        // ignore NotFound
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(std::io::Error::new(
             err.kind(),
             format!("error removing directory {:?}: {:?}", dir, err),
-        )
-    })
+        )),
+    }
 }
 
 pub fn remove_file(file: &Path) -> Result<(), std::io::Error> {
-    std::fs::remove_file(file).map_err(|err| {
-        std::io::Error::new(
+    match std::fs::remove_file(file) {
+        Ok(_) => Ok(()),
+        // ignore NotFound
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(std::io::Error::new(
             err.kind(),
             format!("error removing file {:?}: {:?}", file, err),
-        )
-    })
+        )),
+    }
 }
 
 pub fn file_stem(path: impl AsRef<Path>) -> eyre::Result<String> {

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -106,10 +106,19 @@ where
 }
 
 pub fn remove_dir(dir: &Path) -> Result<(), std::io::Error> {
-    std::fs::remove_dir_all(&dir).map_err(|err| {
+    std::fs::remove_dir_all(dir).map_err(|err| {
         std::io::Error::new(
             err.kind(),
             format!("error removing directory {:?}: {:?}", dir, err),
+        )
+    })
+}
+
+pub fn remove_file(file: &Path) -> Result<(), std::io::Error> {
+    std::fs::remove_file(file).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("error removing file {:?}: {:?}", file, err),
         )
     })
 }


### PR DESCRIPTION
1. It was using `remove_dir` on a file, now it uses `remove_file`
2. Now `remove_dir` and `remove_file` always ignore `NotFound` error