### PR TITLE
specify heap size settings for modules; avm-server 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bd8cd944fb4879cfa072fbbceb24c2cf0468f122d5aeeb5cf532b5e5735359"
+checksum = "6f597f7a1b056dcb08ab9ada0bbd43b978fb1f177de7de72bf4b2021586aa642"
 dependencies = [
  "fluence-faas",
  "log",
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-faas"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb9c5b3178f6374e0b14f12fbfa661c7232b7567cdb65b3c718f1ff38ca597"
+checksum = "999490a4665246d0f6904743b3b5c8b4abe6723529d9c9b72c58a3f3e5df65d6"
 dependencies = [
  "bytesize",
  "cmd_lib",
@@ -1674,7 +1674,7 @@ dependencies = [
  "marine-rs-sdk",
  "marine-rs-sdk-main",
  "marine-runtime",
- "marine-utils 0.3.0",
+ "marine-utils",
  "safe-transmute",
  "serde",
  "serde_derive",
@@ -3139,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "marine-runtime"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be19d5b67f04a8ad65f334a4382b15156a3e130e41c58ea44ba9f95f9966bbaa"
+checksum = "b06f9bc60de3416381b56783f9060f1fcb75fc9dc99c3debdb6c5fc1dd306f52"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -3152,7 +3152,7 @@ dependencies = [
  "marine-it-parser",
  "marine-module-info-parser",
  "marine-module-interface",
- "marine-utils 0.3.0",
+ "marine-utils",
  "multimap",
  "once_cell",
  "parity-wasm",
@@ -3176,12 +3176,6 @@ dependencies = [
  "chrono",
  "quote",
 ]
-
-[[package]]
-name = "marine-utils"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a227f549086e34de1d9d4d1f21823eacdce55839a85fc44a2dfb9f244f3fdcc"
 
 [[package]]
 name = "marine-utils"
@@ -3587,7 +3581,7 @@ dependencies = [
  "json-utils",
  "log",
  "marine-it-parser",
- "marine-utils 0.4.0",
+ "marine-utils",
  "parking_lot 0.11.1",
  "particle-args",
  "particle-execution",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,11 +504,11 @@ dependencies = [
  "air-interpreter-interface",
  "avm-data-store",
  "eyre",
- "fluence-faas",
+ "fluence-faas 0.9.2",
  "log",
  "maplit",
  "parking_lot 0.11.1",
- "polyplets",
+ "polyplets 0.1.2",
  "serde",
  "serde_json",
  "thiserror",
@@ -801,6 +801,15 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cache-padded"
@@ -1637,11 +1646,11 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056981dd5707a42412774d0b95629898f21dbce129b99835ac3f59d39b4a5760"
+checksum = "39bd8cd944fb4879cfa072fbbceb24c2cf0468f122d5aeeb5cf532b5e5735359"
 dependencies = [
- "fluence-faas",
+ "fluence-faas 0.10.0",
  "log",
  "maplit",
  "serde",
@@ -1663,12 +1672,40 @@ dependencies = [
  "marine-module-interface",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
- "marine-runtime",
- "marine-utils",
+ "marine-runtime 0.7.2",
+ "marine-utils 0.2.0",
  "safe-transmute",
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
+ "toml",
+ "wasmer-interface-types-fl",
+ "wasmer-runtime-core-fl",
+ "wasmer-runtime-fl",
+ "wasmer-wasi-fl",
+]
+
+[[package]]
+name = "fluence-faas"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbb9c5b3178f6374e0b14f12fbfa661c7232b7567cdb65b3c718f1ff38ca597"
+dependencies = [
+ "bytesize",
+ "cmd_lib",
+ "itertools 0.9.0",
+ "log",
+ "marine-module-interface",
+ "marine-rs-sdk",
+ "marine-rs-sdk-main",
+ "marine-runtime 0.8.0",
+ "marine-utils 0.3.0",
+ "safe-transmute",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
  "thiserror",
  "toml",
  "wasmer-interface-types-fl",
@@ -3047,18 +3084,19 @@ dependencies = [
 
 [[package]]
 name = "marine-macro"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b05da94255c230b7bf139c39c04447677b5d238579bf38ca7b3fcdc3e04993"
+checksum = "dfc907943772cf966ebe2a2d462d09bc79e898ef102ed065ba3d3abcc93fbb71"
 dependencies = [
  "marine-macro-impl",
+ "marine-rs-sdk-main",
 ]
 
 [[package]]
 name = "marine-macro-impl"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7846a749f35186f923f71b3132a15add0735376e73978f41f552b92e9d43cbab"
+checksum = "bfdbed3a10ae9b22df06bee8cd0023255358935aae8e8daf9d1a006cfaeeb11e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3104,24 +3142,24 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b349c8b5a09045a2a509f7ee5106a52c70ef6782febe9be6748044c6f8c477a"
+checksum = "4d17d44016675abdf18caf3ac1bdd4437cc17ec0db019da141bb06a9ea991726"
 dependencies = [
  "marine-macro",
  "marine-rs-sdk-main",
  "marine-timestamp-macro",
+ "polyplets 0.2.0",
  "serde",
 ]
 
 [[package]]
 name = "marine-rs-sdk-main"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9d9b9ecd87f0dfa8ad9ee594e71f71d8b4f0b819d3b025632a1a6597063088"
+checksum = "8ff262801664ce22f9d274504d6e8088c217034aba0ca431eca8d0258f3699c6"
 dependencies = [
  "log",
- "marine-macro",
  "serde",
 ]
 
@@ -3140,12 +3178,42 @@ dependencies = [
  "marine-it-parser",
  "marine-module-info-parser",
  "marine-module-interface",
- "marine-utils",
+ "marine-utils 0.2.0",
  "multimap",
  "once_cell",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "paste",
- "pwasm-utils",
+ "pwasm-utils 0.12.0",
+ "semver 0.11.0",
+ "serde",
+ "thiserror",
+ "wasmer-interface-types-fl",
+ "wasmer-runtime-core-fl",
+ "wasmer-runtime-fl",
+ "wasmer-wasi-fl",
+]
+
+[[package]]
+name = "marine-runtime"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be19d5b67f04a8ad65f334a4382b15156a3e130e41c58ea44ba9f95f9966bbaa"
+dependencies = [
+ "anyhow",
+ "boolinator",
+ "it-lilo",
+ "log",
+ "marine-it-generator",
+ "marine-it-interfaces",
+ "marine-it-parser",
+ "marine-module-info-parser",
+ "marine-module-interface",
+ "marine-utils 0.3.0",
+ "multimap",
+ "once_cell",
+ "parity-wasm 0.42.2",
+ "paste",
+ "pwasm-utils 0.18.2",
  "semver 0.11.0",
  "serde",
  "thiserror",
@@ -3157,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6e81c03cc0c2f546680bf21e10f3514f69acfa4d4d84a8f2b17b2fcebe8ce9"
+checksum = "85a9f5b1adeff98ac5a14cfc5fa814185a807ba4a0d3849c9f9e9fd868b27d1f"
 dependencies = [
  "chrono",
  "quote",
@@ -3170,6 +3238,12 @@ name = "marine-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dc5838acba84ce4d802d672afd0814fae0ae7098021ae5b06d975e70d09f812"
+
+[[package]]
+name = "marine-utils"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a227f549086e34de1d9d4d1f21823eacdce55839a85fc44a2dfb9f244f3fdcc"
 
 [[package]]
 name = "matches"
@@ -3440,6 +3514,12 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking"
@@ -3846,6 +3926,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyplets"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc56e7803860fa903c27675a17215e1cfb39fb26e111c0b93f6c049f9cf8d8e"
+dependencies = [
+ "marine-macro",
+ "marine-rs-sdk-main",
+ "serde",
+]
+
+[[package]]
 name = "polyval"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,7 +4110,18 @@ checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm",
+ "parity-wasm 0.41.0",
+]
+
+[[package]]
+name = "pwasm-utils"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
+dependencies = [
+ "byteorder",
+ "log",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]
@@ -4328,6 +4430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4526,19 +4634,20 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.6.4"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
+ "rustversion",
  "serde",
  "serde_with_macros",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,18 +497,18 @@ checksum = "dac8b9b7b7f1739169079c382581679b1466cfcb807fb3f7a9723c7a7f78f373"
 
 [[package]]
 name = "avm-server"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e4a5751733da5341d3430f63b6159c5f334d93e4958c4ca668c5ab29dfbc13"
+checksum = "5aba32266b0308a910362f8fe29e1e9d18d04f135c1ed3940b29441e23248c30"
 dependencies = [
  "air-interpreter-interface",
  "avm-data-store",
  "eyre",
- "fluence-faas 0.9.2",
+ "fluence-faas",
  "log",
  "maplit",
  "parking_lot 0.11.1",
- "polyplets 0.1.2",
+ "polyplets",
  "serde",
  "serde_json",
  "thiserror",
@@ -1650,39 +1650,13 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39bd8cd944fb4879cfa072fbbceb24c2cf0468f122d5aeeb5cf532b5e5735359"
 dependencies = [
- "fluence-faas 0.10.0",
+ "fluence-faas",
  "log",
  "maplit",
  "serde",
  "serde_derive",
  "serde_json",
  "toml",
- "wasmer-wasi-fl",
-]
-
-[[package]]
-name = "fluence-faas"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe120218635fd3055bdf3f7e4cf765e2e72866874818bd10f40e2abde882326"
-dependencies = [
- "cmd_lib",
- "itertools 0.9.0",
- "log",
- "marine-module-interface",
- "marine-rs-sdk",
- "marine-rs-sdk-main",
- "marine-runtime 0.7.2",
- "marine-utils 0.2.0",
- "safe-transmute",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "toml",
- "wasmer-interface-types-fl",
- "wasmer-runtime-core-fl",
- "wasmer-runtime-fl",
  "wasmer-wasi-fl",
 ]
 
@@ -1699,7 +1673,7 @@ dependencies = [
  "marine-module-interface",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
- "marine-runtime 0.8.0",
+ "marine-runtime",
  "marine-utils 0.3.0",
  "safe-transmute",
  "serde",
@@ -3149,7 +3123,7 @@ dependencies = [
  "marine-macro",
  "marine-rs-sdk-main",
  "marine-timestamp-macro",
- "polyplets 0.2.0",
+ "polyplets",
  "serde",
 ]
 
@@ -3161,36 +3135,6 @@ checksum = "8ff262801664ce22f9d274504d6e8088c217034aba0ca431eca8d0258f3699c6"
 dependencies = [
  "log",
  "serde",
-]
-
-[[package]]
-name = "marine-runtime"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983262d394c59d4321b141e303eb55015bc412f319d54bbad7f253e4583253b2"
-dependencies = [
- "anyhow",
- "boolinator",
- "it-lilo",
- "log",
- "marine-it-generator",
- "marine-it-interfaces",
- "marine-it-parser",
- "marine-module-info-parser",
- "marine-module-interface",
- "marine-utils 0.2.0",
- "multimap",
- "once_cell",
- "parity-wasm 0.41.0",
- "paste",
- "pwasm-utils 0.12.0",
- "semver 0.11.0",
- "serde",
- "thiserror",
- "wasmer-interface-types-fl",
- "wasmer-runtime-core-fl",
- "wasmer-runtime-fl",
- "wasmer-wasi-fl",
 ]
 
 [[package]]
@@ -3211,9 +3155,9 @@ dependencies = [
  "marine-utils 0.3.0",
  "multimap",
  "once_cell",
- "parity-wasm 0.42.2",
+ "parity-wasm",
  "paste",
- "pwasm-utils 0.18.2",
+ "pwasm-utils",
  "semver 0.11.0",
  "serde",
  "thiserror",
@@ -3235,15 +3179,15 @@ dependencies = [
 
 [[package]]
 name = "marine-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc5838acba84ce4d802d672afd0814fae0ae7098021ae5b06d975e70d09f812"
-
-[[package]]
-name = "marine-utils"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a227f549086e34de1d9d4d1f21823eacdce55839a85fc44a2dfb9f244f3fdcc"
+
+[[package]]
+name = "marine-utils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cff7a23a7f3925a712c34dfb9cd87994012d7743f016fd1533e12ab5a8335ca"
 
 [[package]]
 name = "matches"
@@ -3511,12 +3455,6 @@ checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parity-wasm"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
@@ -3641,6 +3579,7 @@ name = "particle-modules"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
+ "bytesize",
  "eyre",
  "fluence-app-service",
  "fs-utils",
@@ -3648,6 +3587,7 @@ dependencies = [
  "json-utils",
  "log",
  "marine-it-parser",
+ "marine-utils 0.4.0",
  "parking_lot 0.11.1",
  "particle-args",
  "particle-execution",
@@ -3917,16 +3857,6 @@ dependencies = [
 
 [[package]]
 name = "polyplets"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d83e585f13bdc02196e29d726697f0bc55b4aa645b74bac415433f4f83476d"
-dependencies = [
- "marine-rs-sdk",
- "serde",
-]
-
-[[package]]
-name = "polyplets"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc56e7803860fa903c27675a17215e1cfb39fb26e111c0b93f6c049f9cf8d8e"
@@ -4104,24 +4034,13 @@ checksum = "020f86b07722c5c4291f7c723eac4676b3892d47d9a7708dc2779696407f039b"
 
 [[package]]
 name = "pwasm-utils"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm 0.41.0",
-]
-
-[[package]]
-name = "pwasm-utils"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm 0.42.2",
+ "parity-wasm",
 ]
 
 [[package]]
@@ -4662,6 +4581,7 @@ dependencies = [
  "air-interpreter-fs",
  "base64 0.13.0",
  "bs58 0.3.1",
+ "bytesize",
  "clap 3.0.0-beta.4",
  "config-utils",
  "derivative",
@@ -4677,6 +4597,7 @@ dependencies = [
  "prometheus",
  "rand 0.7.3",
  "serde",
+ "serde_with",
  "toml",
  "trust-graph",
 ]

--- a/aquamarine/Cargo.toml
+++ b/aquamarine/Cargo.toml
@@ -16,7 +16,7 @@ control-macro = { path = "../crates/control-macro" }
 fs-utils = { path = "../crates/fs-utils" }
 particle-execution = { path = "../particle-execution" }
 
-avm-server = "0.11.0"
+avm-server = "0.12.0"
 libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 
 futures = "0.3.13"

--- a/aquamarine/src/aqua_runtime.rs
+++ b/aquamarine/src/aqua_runtime.rs
@@ -72,6 +72,7 @@ impl AquaRuntime for AVM<DataStoreError> {
                 current_peer_id: config.current_peer_id.to_string(),
                 air_wasm_path: config.air_interpreter,
                 logging_mask: i32::MAX,
+                max_heap_size: config.max_heap_size,
             };
             let vm = AVM::new(config);
             waker.wake();

--- a/aquamarine/src/config.rs
+++ b/aquamarine/src/config.rs
@@ -39,6 +39,8 @@ pub struct VmConfig {
     /// Dir to store directories shared between services
     /// in the span of a single particle execution
     pub particles_vault_dir: PathBuf,
+    /// Maximum heap size in bytes available for the interpreter.
+    pub max_heap_size: Option<u64>,
 }
 
 impl VmPoolConfig {
@@ -51,13 +53,19 @@ impl VmPoolConfig {
 }
 
 impl VmConfig {
-    pub fn new(current_peer_id: PeerId, base_dir: PathBuf, air_interpreter: PathBuf) -> Self {
+    pub fn new(
+        current_peer_id: PeerId,
+        base_dir: PathBuf,
+        air_interpreter: PathBuf,
+        max_heap_size: Option<u64>,
+    ) -> Self {
         let base_dir = to_abs_path(base_dir);
         Self {
             current_peer_id,
             particles_dir: config_utils::particles_dir(&base_dir),
             particles_vault_dir: config_utils::particles_vault_dir(&base_dir),
             air_interpreter,
+            max_heap_size,
         }
     }
 }

--- a/crates/created-swarm/src/swarm.rs
+++ b/crates/created-swarm/src/swarm.rs
@@ -281,7 +281,7 @@ pub fn aqua_vm_config(
     write_default_air_interpreter(&air_interpreter).expect("write air interpreter");
 
     let avm_base_dir = tmp_dir.join("interpreter");
-    let vm_config = VmConfig::new(peer_id, avm_base_dir.clone(), air_interpreter);
+    let vm_config = VmConfig::new(peer_id, avm_base_dir.clone(), air_interpreter, None);
 
     vm_config
 }

--- a/crates/libp2p/Cargo.toml
+++ b/crates/libp2p/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 
 libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
-libp2p-noise = { package = "fluence-fork-libp2p-noise", version = "0.29.0" }
+libp2p-noise = { package = "fluence-fork-libp2p-noise", version = "0.29.1" }
 multihash = { version = "0.13", features = ["serde-codec"] }
 futures = "0.3.13"
 futures-util = "0.3.5"

--- a/crates/local-vm/Cargo.toml
+++ b/crates/local-vm/Cargo.toml
@@ -16,7 +16,7 @@ aquamarine = { path = "../../aquamarine"}
 air-interpreter-fs = { path = "../air-interpreter-fs" }
 
 air-interpreter-wasm = "=0.18.0"
-avm-server = "0.11.0"
+avm-server = "0.12.0"
 
 libp2p = { version = "0.36.1", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 

--- a/crates/local-vm/src/local_vm.rs
+++ b/crates/local-vm/src/local_vm.rs
@@ -176,6 +176,7 @@ pub fn make_vm(peer_id: PeerId) -> AVM<DataStoreError> {
         current_peer_id: peer_id.to_base58(),
         air_wasm_path: interpreter,
         logging_mask: i32::MAX,
+        max_heap_size: None,
     };
 
     AVM::new(config)

--- a/crates/particle-args/Cargo.toml
+++ b/crates/particle-args/Cargo.toml
@@ -9,7 +9,7 @@ ivalue-utils = { path = "../ivalue-utils" }
 json-utils = { path = "../json-utils" }
 control-macro = { path = "../control-macro" }
 
-avm-server = "0.11.0"
+avm-server = "0.12.0"
 
 serde_json = "1.0.64"
 serde = "1.0.130"

--- a/crates/server-config/Cargo.toml
+++ b/crates/server-config/Cargo.toml
@@ -29,3 +29,5 @@ base64 = "0.13.0"
 num_cpus = "1.13.0"
 eyre = "0.6.5"
 derivative = "2.2.0"
+bytesize = {version = "1.1.0", features = ["serde"]}
+serde_with = "1.11.0"

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -90,7 +90,7 @@ pub struct NodeConfig {
     #[serde(default)]
     pub aquavm_max_heap_size: Option<bytesize::ByteSize>,
 
-    /// Maximum heap size in bytes available for the module.
+    /// Maximum heap size in bytes available for a WASM module.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
     pub app_service_max_heap_size: Option<bytesize::ByteSize>,

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -85,15 +85,20 @@ pub struct NodeConfig {
     #[serde(default = "default_aquavm_pool_size")]
     pub aquavm_pool_size: usize,
 
-    /// Maximum heap size in bytes available for the module.
+    /// Maximum heap size in bytes available for the VM.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
     pub aquavm_max_heap_size: Option<bytesize::ByteSize>,
 
+    /// Maximum heap size in bytes available for the module.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    pub app_service_max_heap_size: Option<bytesize::ByteSize>,
+
     /// Default heap size in bytes available for the module unless otherwise specified.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    pub aquavm_default_heap_size: Option<bytesize::ByteSize>,
+    pub app_service_default_heap_size: Option<bytesize::ByteSize>,
 
     #[serde(default)]
     pub kademlia: KademliaConfig,

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -85,7 +85,7 @@ pub struct NodeConfig {
     #[serde(default = "default_aquavm_pool_size")]
     pub aquavm_pool_size: usize,
 
-    /// Maximum heap size in bytes available for the VM.
+    /// Maximum heap size in bytes available for an interpreter instance.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
     pub aquavm_max_heap_size: Option<bytesize::ByteSize>,

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -12,12 +12,15 @@ use derivative::Derivative;
 use eyre::eyre;
 use libp2p::core::Multiaddr;
 use serde::Deserialize;
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::time::Duration;
 
+#[serde_as]
 #[derive(Clone, Deserialize, Derivative)]
 #[derivative(Debug)]
 pub struct NodeConfig {
@@ -81,6 +84,16 @@ pub struct NodeConfig {
     /// Number of stepper VMs to create. By default, `num_cpus::get() * 2` is used
     #[serde(default = "default_aquavm_pool_size")]
     pub aquavm_pool_size: usize,
+
+    /// Maximum heap size in bytes available for the module.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    pub aquavm_max_heap_size: Option<bytesize::ByteSize>,
+
+    /// Default heap size in bytes available for the module unless otherwise specified.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    pub aquavm_default_heap_size: Option<bytesize::ByteSize>,
 
     #[serde(default)]
     pub kademlia: KademliaConfig,

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -93,12 +93,12 @@ pub struct NodeConfig {
     /// Maximum heap size in bytes available for a WASM module.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    pub app_service_max_heap_size: Option<bytesize::ByteSize>,
+    pub service_max_heap_size: Option<bytesize::ByteSize>,
 
-    /// Default heap size in bytes available for the module unless otherwise specified.
+    /// Default heap size in bytes available for a WASM module unless otherwise specified.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    pub app_service_default_heap_size: Option<bytesize::ByteSize>,
+    pub service_default_heap_size: Option<bytesize::ByteSize>,
 
     #[serde(default)]
     pub kademlia: KademliaConfig,

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -93,12 +93,12 @@ pub struct NodeConfig {
     /// Maximum heap size in bytes available for a WASM module.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    pub service_max_heap_size: Option<bytesize::ByteSize>,
+    pub module_max_heap_size: Option<bytesize::ByteSize>,
 
     /// Default heap size in bytes available for a WASM module unless otherwise specified.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
-    pub service_default_heap_size: Option<bytesize::ByteSize>,
+    pub module_default_heap_size: Option<bytesize::ByteSize>,
 
     #[serde(default)]
     pub kademlia: KademliaConfig,

--- a/crates/server-config/src/services_config.rs
+++ b/crates/server-config/src/services_config.rs
@@ -16,6 +16,7 @@
 
 use fs_utils::{create_dirs, set_write_only, to_abs_path};
 
+use bytesize::ByteSize;
 use libp2p::PeerId;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -42,6 +43,10 @@ pub struct ServicesConfig {
     pub management_peer_id: PeerId,
     /// key to manage builtins services initialization
     pub builtins_management_peer_id: PeerId,
+    /// Maximum heap size in bytes available for the module.
+    pub max_heap_size: Option<ByteSize>,
+    /// Default heap size in bytes available for the module unless otherwise specified.
+    pub default_heap_size: Option<ByteSize>,
 }
 
 impl ServicesConfig {
@@ -52,6 +57,8 @@ impl ServicesConfig {
         envs: HashMap<Vec<u8>, Vec<u8>>,
         management_peer_id: PeerId,
         builtins_management_peer_id: PeerId,
+        max_heap_size: Option<ByteSize>,
+        default_heap_size: Option<ByteSize>,
     ) -> Result<Self, std::io::Error> {
         let base_dir = to_abs_path(base_dir);
 
@@ -65,6 +72,8 @@ impl ServicesConfig {
             envs,
             management_peer_id,
             builtins_management_peer_id,
+            max_heap_size,
+            default_heap_size,
         };
 
         create_dirs(&[

--- a/crates/toy-vms/Cargo.toml
+++ b/crates/toy-vms/Cargo.toml
@@ -9,7 +9,7 @@ aquamarine = { path = "../../aquamarine" }
 particle-protocol = { path = "../../particle-protocol" }
 fluence-libp2p = { path = "../libp2p" }
 
-avm-server = "0.11.0"
+avm-server = "0.12.0"
 
 futures = "0.3.15"
 itertools = "0.10.1"

--- a/particle-builtins/Cargo.toml
+++ b/particle-builtins/Cargo.toml
@@ -20,7 +20,7 @@ now-millis = { path = "../crates/now-millis" }
 toml-utils = { path = "../crates/toml-utils" }
 
 libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
-avm-server = "0.11.0"
+avm-server = "0.12.0"
 
 async-std = { version = "1.9.0", features = ["unstable"] }
 multihash = "0.13.2"

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -461,6 +461,7 @@ where
 
         let name = Args::next("name", &mut args)?;
         let mem_pages_count = Args::next_opt("mem_pages_count", &mut args)?;
+        let max_heap_size = Args::next_opt("max_heap_size", &mut args)?;
         let logger_enabled = Args::next_opt("logger_enabled", &mut args)?;
         let preopened_files = Args::next_opt("preopened_files", &mut args)?;
         let envs = Args::next_opt("envs", &mut args)?.map(table);
@@ -473,6 +474,7 @@ where
             file_name: None,
             config: ModuleConfig {
                 mem_pages_count,
+                max_heap_size,
                 logger_enabled,
                 wasi: Some(WASIConfig {
                     preopened_files,

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -75,7 +75,13 @@ where
         let modules_dir = &config.modules_dir;
         let blueprint_dir = &config.blueprint_dir;
         let vault_dir = &config.particles_vault_dir;
-        let modules = ModuleRepository::new(modules_dir, blueprint_dir, vault_dir);
+        let modules = ModuleRepository::new(
+            modules_dir,
+            blueprint_dir,
+            vault_dir,
+            config.max_heap_size,
+            config.default_heap_size,
+        );
 
         let management_peer_id = config.management_peer_id;
         let builtins_management_peer_id = config.builtins_management_peer_id;

--- a/particle-modules/Cargo.toml
+++ b/particle-modules/Cargo.toml
@@ -14,6 +14,7 @@ service-modules = { path = "../crates/service-modules" }
 
 marine-it-parser = "0.6.8"
 fluence-app-service = "0.11.0"
+marine-utils = "0.4.0"
 
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.64"
@@ -24,6 +25,7 @@ thiserror = "1.0.23"
 parking_lot = "0.11.1"
 eyre = "0.6.5"
 fstrings = "0.2.3"
+bytesize = "1.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/particle-modules/Cargo.toml
+++ b/particle-modules/Cargo.toml
@@ -13,7 +13,7 @@ fs-utils = { path = "../crates/fs-utils" }
 service-modules = { path = "../crates/service-modules" }
 
 marine-it-parser = "0.6.8"
-fluence-app-service = "0.10.1"
+fluence-app-service = "0.11.0"
 
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.64"

--- a/particle-modules/Cargo.toml
+++ b/particle-modules/Cargo.toml
@@ -13,7 +13,7 @@ fs-utils = { path = "../crates/fs-utils" }
 service-modules = { path = "../crates/service-modules" }
 
 marine-it-parser = "0.6.8"
-fluence-app-service = "0.11.0"
+fluence-app-service = "0.11.1"
 marine-utils = "0.4.0"
 
 serde = { version = "1.0.118", features = ["derive"] }

--- a/particle-modules/src/error.rs
+++ b/particle-modules/src/error.rs
@@ -155,6 +155,14 @@ pub enum ModuleError {
         #[source]
         err: serde_json::Error,
     },
+
+    #[error(
+    "Config error: max_heap_size = '{max_heap_size_wanted}' can't be bigger than {max_heap_size_allowed}'"
+    )]
+    MaxHeapSizeOverflow {
+        max_heap_size_wanted: u64,
+        max_heap_size_allowed: u64,
+    },
 }
 
 impl From<ModuleError> for JValue {

--- a/particle-modules/src/modules.rs
+++ b/particle-modules/src/modules.rs
@@ -152,7 +152,7 @@ impl ModuleRepository {
             (None, None) => self.default_heap_size,
         };
 
-        config.config.max_heap_size = heap_size.clone();
+        config.config.max_heap_size = heap_size;
 
         if let (Some(heap_size), Some(max_heap_size)) = (heap_size, self.max_heap_size) {
             if heap_size > max_heap_size {

--- a/particle-modules/src/modules.rs
+++ b/particle-modules/src/modules.rs
@@ -520,6 +520,7 @@ mod tests {
             file_name: None,
             config: TomlFaaSModuleConfig {
                 mem_pages_count: None,
+                max_heap_size: None,
                 logger_enabled: None,
                 wasi: None,
                 mounted_binaries: None,

--- a/particle-modules/src/modules.rs
+++ b/particle-modules/src/modules.rs
@@ -149,7 +149,7 @@ impl ModuleRepository {
             (None, Some(pages_count)) => {
                 Some(ByteSize::b(marine_utils::wasm_pages_to_bytes(pages_count)))
             }
-            (None, None) => self.default_heap_size.clone(),
+            (None, None) => self.default_heap_size,
         };
 
         config.config.max_heap_size = heap_size.clone();

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -24,7 +24,7 @@ fs-utils = { path = "../crates/fs-utils" }
 trust-graph = "0.2.7"
 fluence-identity = "0.3.0"
 air-interpreter-wasm = "=0.18.0"
-avm-server = "0.11.0"
+avm-server = "0.12.0"
 
 libp2p = { version = "0.36.2", package = "fluence-fork-libp2p", features = ["tcp-tokio"] }
 futures = "0.3.13"

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -55,7 +55,7 @@ local-vm = { path = "../crates/local-vm" }
 json-utils = { path = "../crates/json-utils" }
 control-macro = { path = "../crates/control-macro" }
 
-fluence-app-service = "0.10.1"
+fluence-app-service = "0.11.0"
 
 parking_lot = "0.11.1"
 maplit = "1.0.2"

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -55,7 +55,7 @@ local-vm = { path = "../crates/local-vm" }
 json-utils = { path = "../crates/json-utils" }
 control-macro = { path = "../crates/control-macro" }
 
-fluence-app-service = "0.11.0"
+fluence-app-service = "0.11.1"
 
 parking_lot = "0.11.1"
 maplit = "1.0.2"

--- a/particle-node/src/main.rs
+++ b/particle-node/src/main.rs
@@ -143,5 +143,9 @@ fn vm_config(config: &ResolvedConfig) -> VmConfig {
         to_peer_id(&config.root_key_pair.clone().into()),
         config.dir_config.avm_base_dir.clone(),
         config.dir_config.air_interpreter_path.clone(),
+        config
+            .node_config
+            .aquavm_max_heap_size
+            .map(|byte_size| byte_size.as_u64()),
     )
 }

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -108,8 +108,8 @@ impl<RT: AquaRuntime> Node<RT> {
             config.services_envs.clone(),
             config.management_peer_id,
             builtins_peer_id,
-            config.node_config.aquavm_max_heap_size,
-            config.node_config.aquavm_default_heap_size,
+            config.node_config.app_service_max_heap_size,
+            config.node_config.app_service_default_heap_size,
         )
         .expect("create services config");
 

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -108,8 +108,8 @@ impl<RT: AquaRuntime> Node<RT> {
             config.services_envs.clone(),
             config.management_peer_id,
             builtins_peer_id,
-            config.node_config.service_max_heap_size,
-            config.node_config.service_default_heap_size,
+            config.node_config.module_max_heap_size,
+            config.node_config.module_default_heap_size,
         )
         .expect("create services config");
 

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -108,8 +108,8 @@ impl<RT: AquaRuntime> Node<RT> {
             config.services_envs.clone(),
             config.management_peer_id,
             builtins_peer_id,
-            config.node_config.app_service_max_heap_size,
-            config.node_config.app_service_default_heap_size,
+            config.node_config.service_max_heap_size,
+            config.node_config.service_default_heap_size,
         )
         .expect("create services config");
 

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -108,6 +108,8 @@ impl<RT: AquaRuntime> Node<RT> {
             config.services_envs.clone(),
             config.management_peer_id,
             builtins_peer_id,
+            config.node_config.aquavm_max_heap_size,
+            config.node_config.aquavm_default_heap_size,
         )
         .expect("create services config");
 
@@ -390,6 +392,7 @@ mod tests {
             to_peer_id(&config.root_key_pair.clone().into()),
             config.dir_config.avm_base_dir.clone(),
             config.dir_config.air_interpreter_path.clone(),
+            None,
         );
         let mut node: Box<Node<AVM<_>>> =
             Node::new(config, vm_config, "some version").expect("create node");

--- a/particle-services/Cargo.toml
+++ b/particle-services/Cargo.toml
@@ -16,7 +16,7 @@ server-config = { path = "../crates/server-config" }
 fluence-libp2p = { path = "../crates/libp2p" }
 particle-execution = { path = "../particle-execution" }
 
-fluence-app-service = "0.11.0"
+fluence-app-service = "0.11.1"
 
 parking_lot = "0.11.0"
 serde_json = "1.0.64"

--- a/particle-services/Cargo.toml
+++ b/particle-services/Cargo.toml
@@ -16,7 +16,7 @@ server-config = { path = "../crates/server-config" }
 fluence-libp2p = { path = "../crates/libp2p" }
 particle-execution = { path = "../particle-execution" }
 
-fluence-app-service = "0.10.1"
+fluence-app-service = "0.11.0"
 
 parking_lot = "0.11.0"
 serde_json = "1.0.64"

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -230,9 +230,9 @@ impl ParticleAppServices {
                 .map(|sts| {
                     sts.into_iter()
                         .map(|st| SecurityTetraplet {
-                            peer_pk: st.triplet.peer_pk,
-                            service_id: st.triplet.service_id,
-                            function_name: st.triplet.function_name,
+                            peer_pk: st.peer_pk,
+                            service_id: st.service_id,
+                            function_name: st.function_name,
                             json_path: st.json_path,
                         })
                         .collect()
@@ -435,6 +435,8 @@ mod tests {
             HashMap::new(),
             management_pid,
             to_peer_id(&startup_kp),
+            None,
+            None,
         )
         .unwrap();
 
@@ -442,6 +444,8 @@ mod tests {
             &config.modules_dir,
             &config.blueprint_dir,
             &config.particles_vault_dir,
+            None,
+            None,
         );
 
         ParticleAppServices::new(config, repo)

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -522,6 +522,7 @@ mod tests {
             file_name: None,
             config: TomlFaaSModuleConfig {
                 mem_pages_count: None,
+                max_heap_size: None,
                 logger_enabled: None,
                 wasi: None,
                 mounted_binaries: None,


### PR DESCRIPTION
- bump fluence-app-service to 0.11.1
- bump avm-server to 0.12.0
- add aquavm_max_heap_size, module_max_heap_size and module_default_heap_size to node's config
- check max_heap_size overflow in `add_module`