### PR TITLE
Scheduled scripts: derive particle_id from script_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Fluence Project
 
-**Fluence is a peer-to-peer computing protocol and a software licensing system.** 
+**Fluence is a peer-to-peer computing protocol and a software licensing system.**
 
-*The project is a work in progress!* 
+*The project is a work in progress!*
 
 [fluence.network](https://fluence.network)
 

--- a/crates/log-utils/src/lib.rs
+++ b/crates/log-utils/src/lib.rs
@@ -24,6 +24,7 @@ pub fn enable_logs() {
     env_logger::builder()
         .format_timestamp_millis()
         .filter_level(log::LevelFilter::Info)
+        .filter(Some("script_storage"), Trace)
         .filter(Some("aquamarine"), Trace)
         .filter(Some("network"), Trace)
         .filter(Some("network_api"), Trace)

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -243,22 +243,11 @@ where
         let delay = delay.map(Duration::from_secs);
         let delay = get_delay(delay, interval);
 
-        let mut times = parse_from_str("times", &mut args)?;
-        // Check that `interval` doesn't conflict with `times`
-        if interval.is_none() {
-            if times.is_none() || times <= Some(1) {
-                times = Some(1);
-            } else {
-                let err = JError::new("You must specify interval to run script more than once");
-                Err(err)?;
-            }
-        }
-
         let creator = params.init_peer_id;
 
         let id = self
             .script_storage
-            .add_script(script, interval, delay, creator, times)?;
+            .add_script(script, interval, delay, creator)?;
 
         Ok(json!(id))
     }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -17,6 +17,7 @@
 use std::borrow::{Borrow, Cow};
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
+use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::num::ParseIntError;
 use std::ops::{Mul, Try};
@@ -235,17 +236,29 @@ where
 
         let script: String = Args::next("script", &mut args)?;
 
-        let interval = parse_u64("interval_sec", &mut args)?;
+        let interval = parse_from_str("interval_sec", &mut args)?;
         let interval = interval.map(Duration::from_secs);
 
-        let delay = parse_u64("delay_sec", &mut args)?;
+        let delay = parse_from_str("delay_sec", &mut args)?;
         let delay = delay.map(Duration::from_secs);
         let delay = get_delay(delay, interval);
 
+        let mut times = parse_from_str("times", &mut args)?;
+        // Check that `interval` doesn't conflict with `times`
+        if interval.is_none() {
+            if times.is_none() || times <= Some(1) {
+                times = Some(1);
+            } else {
+                let err = JError::new("You must specify interval to run script more than once");
+                Err(err)?;
+            }
+        }
+
         let creator = params.init_peer_id;
+
         let id = self
             .script_storage
-            .add_script(script, interval, delay, creator)?;
+            .add_script(script, interval, delay, creator, times)?;
 
         Ok(json!(id))
     }
@@ -279,7 +292,7 @@ where
                         "src": script.src,
                         "failures": script.failures,
                         "interval": script.interval.map(|i| pretty(i).to_string()),
-                        "owner": script.owner.to_string(),
+                        "owner": script.creator.to_string(),
                     })
                 })
                 .collect(),
@@ -293,7 +306,7 @@ where
         let mut args = args.function_args.into_iter();
 
         let dur_field = "duration_ms";
-        let duration = parse_u64(dur_field, &mut args)?;
+        let duration = parse_from_str(dur_field, &mut args)?;
         let duration = duration.ok_or(ArgsError::MissingField(dur_field))?;
         let duration = Duration::from_millis(duration);
 
@@ -710,26 +723,30 @@ fn wrap_unit(r: Result<(), JError>) -> FunctionOutcome {
     }
 }
 
-fn parse_u64(
+fn parse_from_str<T>(
     field: &'static str,
     mut args: &mut impl Iterator<Item = JValue>,
-) -> Result<Option<u64>, JError> {
+) -> Result<Option<T>, JError>
+where
+    T: FromStr + for<'a> Deserialize<'a>,
+    <T as FromStr>::Err: std::error::Error + 'static,
+{
     #[derive(thiserror::Error, Debug)]
-    #[error("Error while deserializing field {field_name}: not a valid u64")]
-    struct Error {
+    #[error("Error while deserializing field {field_name}")]
+    struct Error<E: std::error::Error> {
         field_name: String,
         #[source]
-        err: ParseIntError,
+        err: E,
     }
 
     #[derive(serde::Deserialize, Debug)]
     #[serde(untagged)]
-    pub enum Period {
+    pub enum Either<T> {
         String(String),
-        Number(u64),
+        Target(T),
     }
 
-    let number: Option<Period> = Args::next_opt(field, &mut args)?;
+    let number: Option<Either<T>> = Args::next_opt(field, &mut args)?;
 
     if number.is_none() {
         return Ok(None);
@@ -737,11 +754,11 @@ fn parse_u64(
 
     number
         .map(|i| match i {
-            Period::String(s) => Ok(s.parse::<u64>()?),
-            Period::Number(n) => Ok(n),
+            Either::String(s) => Ok(s.parse::<T>()?),
+            Either::Target(n) => Ok(n),
         })
         .transpose()
-        .map_err(|err| {
+        .map_err(|err: T::Err| {
             Error {
                 field_name: field.to_string(),
                 err,

--- a/particle-node/tests/script_storage.rs
+++ b/particle-node/tests/script_storage.rs
@@ -610,6 +610,7 @@ fn add_script_random_delay() {
     let res = client.wait_particle_args(now_id).unwrap().pop().unwrap();
     let now = res.as_u64().unwrap();
 
+    // client.timeout = Duration::from_secs(120);
     let res = client.receive_args().wrap_err("receive").unwrap();
     let res = res.into_iter().next().unwrap().as_u64().unwrap();
     let eps = 2u64;

--- a/particle-node/tests/script_storage.rs
+++ b/particle-node/tests/script_storage.rs
@@ -610,7 +610,6 @@ fn add_script_random_delay() {
     let res = client.wait_particle_args(now_id).unwrap().pop().unwrap();
     let now = res.as_u64().unwrap();
 
-    // client.timeout = Duration::from_secs(120);
     let res = client.receive_args().wrap_err("receive").unwrap();
     let res = res.into_iter().next().unwrap().as_u64().unwrap();
     let eps = 2u64;

--- a/script-storage/src/script_storage.rs
+++ b/script-storage/src/script_storage.rs
@@ -266,9 +266,7 @@ async fn execute_command(command: Command, scripts: &Mutex<HashMap<ScriptId, Scr
             // If interval isn't set, script should be executed only once
             let times = if interval.is_none() { Some(1) } else { None };
             let script = Script::new(script, interval, delay, creator, times);
-            log::info!("adding script {:?}", script);
             unlock(scripts, |scripts| scripts.insert(uuid, script)).await;
-            log::info!("done");
         }
         Command::RemoveScript {
             uuid,

--- a/script-storage/src/script_storage.rs
+++ b/script-storage/src/script_storage.rs
@@ -117,8 +117,6 @@ pub enum Command {
         interval: Option<Duration>,
         delay: Duration,
         creator: PeerId,
-        /// How many times the script should be executed
-        times: Option<u32>,
     },
     RemoveScript {
         uuid: String,
@@ -263,9 +261,10 @@ async fn execute_command(command: Command, scripts: &Mutex<HashMap<ScriptId, Scr
             interval,
             delay,
             creator,
-            times,
         } => {
             let uuid = ScriptId(Arc::new(uuid));
+            // If interval isn't set, script should be executed only once
+            let times = if interval.is_none() { Some(1) } else { None };
             let script = Script::new(script, interval, delay, creator, times);
             log::info!("adding script {:?}", script);
             unlock(scripts, |scripts| scripts.insert(uuid, script)).await;
@@ -363,7 +362,6 @@ impl ScriptStorageApi {
         interval: Option<Duration>,
         delay: Duration,
         creator: PeerId,
-        times: Option<u32>,
     ) -> Result<String, ScriptStorageError> {
         let uuid = uuid::Uuid::new_v4().to_string();
 
@@ -373,7 +371,6 @@ impl ScriptStorageApi {
             interval,
             delay,
             creator,
-            times,
         })?;
 
         Ok(uuid)


### PR DESCRIPTION
Also:
- Add debug logs to understand why failed scripts aren't removed
- Express `oneshot` logic explicitly with `executions` and `times` state variables